### PR TITLE
add more info about python/node version

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,14 @@ The Nightfall demonstration requires the following software to run:
   - Launch Docker Desktop (on Mac, it is on the menu bar) and set memory to 8GB with 4GB of swap
     space (minimum - 12GB memory is better) or 16GB of memory with 512MB of swap. **The default
     values for Docker Desktop will NOT work. No, they really won't**.
-- Node (tested with 10.15.3) with npm and node-gyp
-  - If running macOS, install Xcode then run `xcode-select —install` to install these.
+- Python
+  - Be sure npm is setup to use v2.7 of python, not python3.
+  - You may need to run `npm config set python /usr/bin/python2.7` (or wherever your python 2 location is)
+- Node (tested with node 10.15.3) with npm and node-gyp.
+  - Will not work with node v12.
+  - If using mac/brew, then you may need to run `brew install node@10` and `brew link --overwrite node@10 --force`
+- Xcode Command line tools:
+  - If running macOS, install Xcode then run `xcode-select --install` to install command line tools.
 - docker-proxy
   - <https://github.com/aj-may/docker-proxy/>
 
@@ -109,6 +115,7 @@ docker-compose build
 :night_with_stars: We're ready to go! Run the demo:
 
 ```sh
+cd ..
 ./zkp-demo
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ The Nightfall demonstration requires the following software to run:
     space (minimum - 12GB memory is better) or 16GB of memory with 512MB of swap. **The default
     values for Docker Desktop will NOT work. No, they really won't**.
 - Python
-  - Be sure npm is setup to use v2.7 of python, not python3.
+  - Be sure npm is setup to use v2.7 of python, not python3. To check the python version, run `python --version`
   - You may need to run `npm config set python /usr/bin/python2.7` (or wherever your python 2 location is)
 - Node (tested with node 10.15.3) with npm and node-gyp.
-  - Will not work with node v12.
+  - Will not work with node v12. To check the node version, run `node --version`
   - If using mac/brew, then you may need to run `brew install node@10` and `brew link --overwrite node@10 --force`
 - Xcode Command line tools:
   - If running macOS, install Xcode then run `xcode-select --install` to install command line tools.
@@ -112,10 +112,9 @@ If you have pulled new changes from the repo, then first run
 docker-compose build
 ```
 
-:night_with_stars: We're ready to go! Run the demo:
+:night_with_stars: We're ready to go! Be sure to be in the main directory and run the demo:
 
 ```sh
-cd ..
 ./zkp-demo
 ```
 


### PR DESCRIPTION
I tried to run with node v12, but was unsuccessful. I finally figured out that node v10 was what would get it to work. (Yes, despite that the comment that was there; I thought the v10.15.3 was referring to the beta for OSX.)