### PR TITLE
Enable Solidity syntax highlighting on GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
By adding a .gitattributes file to identify *.sol files as Solidity