### PR TITLE
fix: security update - prevent duplicate nullifier - ft-transfer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,36 +25,7 @@ As well as this file, please be sure to check out:
 - [SECURITY.md](./SECURITY.md) to learn about how we handle security issues.
 
 ## Security Updates
-Critical security updates will be listed here. If you had previously installed Nightfall prior to one of these security updates, please pull the latest code,  and follow the extra re-installation steps outlined here.  
-
----
-
-**date** (yyyy-mm-dd): 2019-06-04  
-**description**: Updated G2 library  
-**tag \#**: n/a  
-**PR \#**: [#23](https://github.com/EYBlockchain/nightfall/pull/23)  
-**issue \#**: [#14](https://github.com/EYBlockchain/nightfall/issues/14)  
-**re-installation**:  
-`docker-compose build zkp`  
-
----  
-
-**date**: 2019-06-04  
-**description**: Burn payTo bug  
-**tag \#**:  v1.0.1  
-**PR \#**: [#26](https://github.com/EYBlockchain/nightfall/pull/26)  
-**issue \#**: [#19](https://github.com/EYBlockchain/nightfall/issues/19)  
-**re-installation**:  
-`cd zkp-utils`  
-`npm ci`  
-`cd ../zkp`  
-`npm ci`  
-`npm run setup -- -i gm17/nft-burn/`  
-`npm run setup -- -i gm17/ft-burn/`  
-`cd ..`  
-`docker-compose build zkp`  
-
----  
+Critical security updates will be listed [here](./security-updates.md). If you had previously installed Nightfall prior to one of these security updates, please pull the latest code, and follow the extra re-installation steps.  
 
 ## Getting started
 

--- a/security-updates.md
+++ b/security-updates.md
@@ -1,0 +1,42 @@
+# Security Updates  
+
+Critical security updates will be listed here (ordered newest to oldest). If you had previously installed Nightfall prior to one of these security updates, please pull the latest code, and follow every set of re-installation steps.
+
+---
+
+**date**: 2019-06-07  
+**description**: Prevent duplicate nullifier - ft-transfer
+**tag \#**:  v1.0.2  
+**PR \#**: [#28](https://github.com/EYBlockchain/nightfall/pull/28)  
+**issue \#**: n/a  
+**re-installation**:  
+`docker-compose build zkp`  
+
+---
+
+**date**: 2019-06-06  
+**description**: Burn payTo bug  
+**tag \#**:  v1.0.1  
+**PR \#**: [#26](https://github.com/EYBlockchain/nightfall/pull/26)  
+**issue \#**: [#19](https://github.com/EYBlockchain/nightfall/issues/19)  
+**re-installation**:  
+`cd zkp-utils`  
+`npm ci`  
+`cd ../zkp`  
+`npm ci`  
+`npm run setup -- -i gm17/nft-burn/`  
+`npm run setup -- -i gm17/ft-burn/`  
+`cd ..`  
+`docker-compose build zkp`  
+
+---
+
+**date**: 2019-06-06  
+**description**: Updated G2 library  
+**tag \#**: n/a  
+**PR \#**: [#23](https://github.com/EYBlockchain/nightfall/pull/23)  
+**issue \#**: [#14](https://github.com/EYBlockchain/nightfall/issues/14)  
+**re-installation**:  
+`docker-compose build zkp`  
+
+---

--- a/zkp/contracts/FTokenShield.sol
+++ b/zkp/contracts/FTokenShield.sol
@@ -174,8 +174,10 @@ depth row  width  st#     end#
 
 
     require(roots[inputRoot] == inputRoot, "The input root has never been the root of the Merkle Tree");
-    require(ns[nc]==0, "The token has already been nullified!");
-    require(ns[nd]==0, "The token has already been nullified!");
+    require(nc != nd, "The nullifiers nc and nd must be different!");
+    require(ze != zf, "The token commitments ze and zf must be different!");
+    require(ns[nc] == 0, "The token has already been nullified!");
+    require(ns[nd] == 0, "The token has already been nullified!");
 
     ns[nc] = nc; //remember we spent it
     ns[nd] = nd; //remember we spent it


### PR DESCRIPTION
Bug found by @benjamindelmee 

Affects only the ft-transfer.

Added two `require` statements:  
- to ensure the nullifiers N_c and N_d are different (to avoid double-spend of Z_c by publishing N_c and a second N_c).
- to prevent Alice from accidentally sending duplicate Z_e and Z_f values.

The underlying node.js application would never have created this scenario, but people using the smart contracts more generally could have exploited this.

Updated the 'Security Updates' section of the README.

Moved the bulk of the 'Security Updates' body of text from the README to its own file `security-updates.md`, because it was becoming too big for the 'front page' readme.



