### PR TITLE
Add basic Travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - 11
+script:
+  - npm lint


### PR DESCRIPTION
This adds a basic Travis file so that Travis builds may be turned on for this repository.

Of course this test script can be improved. But *some* test script is required to turn on builds. And it is easier to improve the script when builds are turned on.