### PR TITLE
Feature: Burn ERC20/ERC721 token and transfer

### DIFF
--- a/API-Gateway/src/services/coin.js
+++ b/API-Gateway/src/services/coin.js
@@ -172,7 +172,12 @@ export async function burnCoin(req, res, next) {
     data.action_type = 'burned';
 
     const senderAddress = req.user.address;
-    await db.updateCoinForBurn(req.user, _.extend(req.body, data, { account: senderAddress }));
+    await db.updateCoinForBurn(req.user, {
+      ...req.body,
+      ...data,
+      account: senderAddress,
+      receiver_name: (req.body.payTo || req.user.name)
+    });
 
     const user = await db.fetchUser(req.user);
 

--- a/API-Gateway/src/services/token.js
+++ b/API-Gateway/src/services/token.js
@@ -201,6 +201,7 @@ export async function burnToken(req, res, next) {
       S_A: req.body.S_A,
       z_A: req.body.z_A,
       z_A_index: req.body.z_A_index,
+      receiver_name: req.body.payTo || req.user.name,
       is_burned: true,
     });
 

--- a/API-Gateway/src/services/token.js
+++ b/API-Gateway/src/services/token.js
@@ -173,7 +173,8 @@ export async function transferToken(req, res, next) {
           S_A: '0xf4c7028d78d140333a36381540e70e6210895a994429fb0483fb91',
           z_A: '0xe0e327cee19c16949a829977a1e3a36b92c2ef22b735b6d7af6c33',
           Sk_A: '0x99ba1bd95aef4bab8c4f8f73ccc804913c58828f6e11ed4760b2cd',
-          z_A_index: 1
+          z_A_index: 1,
+          payTo: 'bob',
       }
      * @param {*} req
      * @param {*} res
@@ -181,6 +182,7 @@ export async function transferToken(req, res, next) {
 export async function burnToken(req, res, next) {
   const response = new Response();
   try {
+    const payToAddress = (await offchain.getAddressFromName(req.body.payTo || req.user.name)).address;
     // Release the public token from escrow:
     // Nullify the burnor's 'token commitment' within the shield contract.
     // Transfer the public token from the shield contract to the owner.
@@ -190,6 +192,7 @@ export async function burnToken(req, res, next) {
       Sk_A: req.body.Sk_A,
       z_A: req.body.z_A,
       z_A_index: req.body.z_A_index,
+      payTo: payToAddress,
     });
 
     await db.updateToken(req.user, {

--- a/database/src/business/coin.service.js
+++ b/database/src/business/coin.service.js
@@ -189,7 +189,8 @@ module.exports = class CoinService {
             coin_value,
             salt,
             burn_coin_commitment,
-            burn_coin_commitment_index
+            burn_coin_commitment_index,
+            receiver_name,
         } = coinMapper(data);
         //Add coin burn transaction to coin-transaction history
         await this.coinTransactionService.addNewCoinTransaction(data);
@@ -205,7 +206,8 @@ module.exports = class CoinService {
                     'burn_coin_commitment': burn_coin_commitment,
                     'burn_timestamp': new Date(),
                     burn_coin_commitment_index,
-                    'type': 'burned'
+                    'type': 'burned',
+                    receiver_name,
                 }
             }
         );

--- a/database/src/business/coin_transaction.service.js
+++ b/database/src/business/coin_transaction.service.js
@@ -31,7 +31,8 @@ module.exports = class CoinTransactionService {
 			public_key,
 			salt,
 			coin_commitment,
-			coin_commitment_index
+			coin_commitment_index,
+			receiver_name
 		}= coinMapper(data);
 
 		let coinTransaction = {
@@ -42,7 +43,8 @@ module.exports = class CoinTransactionService {
 			coin_commitment,
 			coin_commitment_index,
 			type,
-			timestamp: new Date()
+			timestamp: new Date(),
+			[receiver_name ? 'receiver_name' : undefined] : receiver_name,
 		}
 		return coinTransaction;
 	}

--- a/database/src/mappers/coin-transaction.js
+++ b/database/src/mappers/coin-transaction.js
@@ -7,7 +7,8 @@ const coinMapper = ({
 	coin_index,
   burnedCoin,
 	burnedCoin_index,
-  action_type
+  action_type,
+  receiver_name
 }) => {
   return {
   	account: (account || '').toLowerCase(),
@@ -16,7 +17,8 @@ const coinMapper = ({
 		salt: (S_A || '').toLowerCase(),
     coin_commitment: (coin || burnedCoin || '').toLowerCase(),
 		coin_commitment_index: (coin_index || coin_index===0)? coin_index : (burnedCoin_index || burnedCoin_index===0)? burnedCoin_index : '',
-    type: (action_type || '').toLowerCase()
+    type: (action_type || '').toLowerCase(),
+    receiver_name,
   }
 }
 

--- a/ui/src/app/pages/burn-coin/burn-coin.component.html
+++ b/ui/src/app/pages/burn-coin/burn-coin.component.html
@@ -21,50 +21,71 @@
       </div>
 
       <div class="box-body">
-        <div class="form-group" *ngIf="transactions && transactions.length">
-          <label for="name mb-1">Select Coin</label>
-          <div class="row col-sm-12">
-            <ng-select
-              #select
-              [items]="transactions"
-              class="custom"
-              autoFocus
-              [virtualScroll]="true"
-              [multiple]="true"
-              [loading]="loading"
-              [maxSelectedItems]="1"
-              [searchFn]="customSearchFn"
-              [(ngModel)]="selectedCoinList"
-              placeholder="Select Private {{ ftName }}"
-              style="width:50%;"
-            >
-              <ng-template ng-label-tmp let-item="item">
-                <span aria-hidden="true" class="ng-value-icon left" (click)="onRemove(item)"
-                  >×</span
-                >
-                <b>{{ utilService.convertToNumber(item.coin_value) }} </b>Coin &nbsp;
-              </ng-template>
-              <ng-template ng-option-tmp let-item="item" let-index="index">
-                <b>{{ utilService.convertToNumber(item.coin_value) }} </b>Coin ({{
-                  item.coin_commitment.slice(0, 20)
-                }})...
-              </ng-template>
-            </ng-select>
-          </div>
+        <div class="containe-form" *ngIf="transactions && transactions.length">
+            <div class="form-group">
+                <label for="name mb-1">Select Coin</label>
+                <div class="row col-sm-12">
+                  <ng-select
+                    #select
+                    [items]="transactions"
+                    class="custom"
+                    autoFocus
+                    [virtualScroll]="true"
+                    [multiple]="true"
+                    [loading]="loading"
+                    [maxSelectedItems]="1"
+                    [searchFn]="customSearchFn"
+                    [(ngModel)]="selectedCoinList"
+                    placeholder="Select Private {{ ftName }}"
+                    style="width:50%;"
+                  >
+                    <ng-template ng-label-tmp let-item="item">
+                      <span aria-hidden="true" class="ng-value-icon left" (click)="onRemove(item)"
+                        >×</span
+                      >
+                      <b>{{ utilService.convertToNumber(item.coin_value) }} </b>Coin &nbsp;
+                    </ng-template>
+                    <ng-template ng-option-tmp let-item="item" let-index="index">
+                      <b>{{ utilService.convertToNumber(item.coin_value) }} </b>Coin ({{
+                        item.coin_commitment.slice(0, 20)
+                      }})...
+                    </ng-template>
+                  </ng-select>
+                </div>
+              </div>
+      
+              <div class="form-group" >
+                <label for="publickey">Select Recipient</label>
+                <div class="row">
+                  <div class="col-sm-6">
+                    <select
+                      class="form-control"
+                      id="publickey"
+                      name="sellist1"
+                      [(ngModel)]="receiverName"
+                      required
+                    >
+                      <option [ngValue]="undefined" selected>Select </option>
+                      <option *ngFor="let user of users" value="{{ user }}">{{ user }}</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+      
+              <div class="row form-group" *ngIf="transactions && transactions.length">
+                <div class="col-md-6">
+                  <button
+                    type="submit"
+                    class="btn btn-md btn-primary"
+                    [disabled]="!selectedCoinList.length || !receiverName"
+                    (click)="initiateBurn()"
+                  >
+                    Burn {{ ftName }} Commitment
+                  </button>
+                </div>
+              </div>
         </div>
-
-        <div class="row form-group" *ngIf="transactions && transactions.length">
-          <div class="col-md-6">
-            <button
-              type="submit"
-              class="btn btn-md btn-primary"
-              [disabled]="!selectedCoinList.length"
-              (click)="initiateBurn()"
-            >
-              Burn {{ ftName }} Commitment
-            </button>
-          </div>
-        </div>
+        
         <div class="text-center" *ngIf="!transactions">No {{ ftName }} Commitment's Found</div>
       </div>
     </div>

--- a/ui/src/app/pages/burn-coin/burn-coin.component.ts
+++ b/ui/src/app/pages/burn-coin/burn-coin.component.ts
@@ -4,13 +4,14 @@ import { CoinApiService } from '../../services/coins/coin-api.service';
 import { Router } from '@angular/router';
 import {UtilService} from '../../services/utils/util.service'
 import { NgSelectComponent } from '@ng-select/ng-select';
+import { AccountsApiService } from '../../services/accounts/accounts-api.service';
 /**
  *  Burn coin component, which is used for rendering the page of burn private coin.
  */
 @Component({
   selector: 'app-burn-coin',
   templateUrl: './burn-coin.component.html',
-  providers: [CoinApiService, UtilService],
+  providers: [AccountsApiService, CoinApiService, UtilService],
   styleUrls: ['./burn-coin.component.css']
 })
 export class BurnCoinComponent implements OnInit , AfterContentInit{
@@ -44,6 +45,16 @@ export class BurnCoinComponent implements OnInit , AfterContentInit{
   ftName:string;
 
   /**
+   * To store all users 
+   */
+  users: any;
+
+/**
+ * Name of the transferee
+ */
+  receiverName: string;
+
+  /**
    * Reference of combo box
    */
   @ViewChild('select') select: NgSelectComponent;
@@ -52,6 +63,7 @@ export class BurnCoinComponent implements OnInit , AfterContentInit{
     private toastr: ToastrService,
     private utilService: UtilService,
     private coinApiService: CoinApiService,
+    private accountApiService: AccountsApiService,
     private router: Router
   ) {
     this.fetchCoins();
@@ -60,6 +72,7 @@ export class BurnCoinComponent implements OnInit , AfterContentInit{
 
   ngOnInit () {
     this.ftName = localStorage.getItem('ftName');
+    this.getUsers();
   }
 
   ngAfterContentInit(){
@@ -115,7 +128,8 @@ export class BurnCoinComponent implements OnInit , AfterContentInit{
       coin['salt'],
       coin['coin_commitment_index'],
       coin['coin_commitment'],
-      localStorage.getItem('publickey')
+      localStorage.getItem('publickey'),
+      this.receiverName
     ).subscribe( data => {
         this.isRequesting = false;
         this.toastr.success('Burned Coin ' + coin['coin_commitment'],);
@@ -154,6 +168,22 @@ export class BurnCoinComponent implements OnInit , AfterContentInit{
     term = term.toLocaleLowerCase();
     let itemToSearch = this.utilService.convertToNumber(item.coin_value).toString().toLocaleLowerCase();
     return itemToSearch.indexOf(term) > -1;
+  }
+
+  /**
+   * Method to retrive all users.
+   * 
+   */
+  getUsers () {
+    this.isRequesting = true;
+    this.accountApiService.getUsers().subscribe(
+      data => {
+        this.isRequesting = false;
+        this.users = data['data'];
+      }, error => {
+        this.isRequesting = false;
+        this.toastr.error('Please try again.', "Error");
+      })
   }
   
 }

--- a/ui/src/app/pages/burn-token/burn-token.component.html
+++ b/ui/src/app/pages/burn-token/burn-token.component.html
@@ -55,24 +55,24 @@
                   </div>
                 </div>
               </div>
-
               <div class="form-group" >
-                  <label for="publickey">Select Recipient</label>
-                  <div class="row">
-                    <div class="col-sm-6">
-                      <select
-                        class="form-control"
-                        id="publickey"
-                        name="sellist1"
-                        [(ngModel)]="receiverName"
-                        required
-                      >
-                        <option [ngValue]="undefined" selected>Select </option>
-                        <option *ngFor="let user of users" value="{{ user }}">{{ user }}</option>
-                      </select>
-                    </div>
+                <label for="publickey">Select Recipient</label>
+                <div class="row">
+                  <div class="col-sm-12">
+                    <select
+                      class="form-control"
+                      style="width:75%"
+                      id="publickey"
+                      name="sellist1"
+                      [(ngModel)]="receiverName"
+                      required >
+                      <option [ngValue]="undefined" selected>Select </option>
+                      <option *ngFor="let user of users" value="{{ user }}">{{ user }}</option>
+                    </select>
                   </div>
                 </div>
+              </div>
+              
 
               <div class="row">
                 <div class="form-group col-md-6">

--- a/ui/src/app/pages/burn-token/burn-token.component.html
+++ b/ui/src/app/pages/burn-token/burn-token.component.html
@@ -55,10 +55,29 @@
                   </div>
                 </div>
               </div>
+
+              <div class="form-group" >
+                  <label for="publickey">Select Recipient</label>
+                  <div class="row">
+                    <div class="col-sm-6">
+                      <select
+                        class="form-control"
+                        id="publickey"
+                        name="sellist1"
+                        [(ngModel)]="receiverName"
+                        required
+                      >
+                        <option [ngValue]="undefined" selected>Select </option>
+                        <option *ngFor="let user of users" value="{{ user }}">{{ user }}</option>
+                      </select>
+                    </div>
+                  </div>
+                </div>
+
               <div class="row">
                 <div class="form-group col-md-6">
                   <button
-                    [disabled]="!selectedTokenList.length"
+                    [disabled]="!selectedTokenList.length || !receiverName"
                     type="button"
                     class="btn btn-md btn-primary"
                     (click)="initiateBurn()"

--- a/ui/src/app/pages/burn-token/burn-token.component.ts
+++ b/ui/src/app/pages/burn-token/burn-token.component.ts
@@ -3,6 +3,7 @@ import { ToastrService } from 'ngx-toastr';
 import { Router } from '@angular/router';
 import { TokenApiService } from '../../services/tokens/token-api.service';
 import { NgSelectComponent } from '@ng-select/ng-select';
+import { AccountsApiService } from '../../services/accounts/accounts-api.service';
 
 /**
  * Burn private token component, which is used for rendering the page of burn ERC-721 commitment.
@@ -10,7 +11,7 @@ import { NgSelectComponent } from '@ng-select/ng-select';
 @Component({
   selector: 'app-burn-token',
   templateUrl: './burn-token.component.html',
-  providers: [TokenApiService],
+  providers: [TokenApiService, AccountsApiService],
   styleUrls: ['./burn-token.component.css']
 })
 export class BurnTokenComponent implements OnInit, AfterContentInit {
@@ -42,6 +43,16 @@ export class BurnTokenComponent implements OnInit, AfterContentInit {
   nftName:string;
 
   /**
+   * To store all users 
+   */
+  users: any;
+
+  /**
+   * Name of the transferee
+   */
+  receiverName: string;
+
+  /**
    * Reference of combo box
    */
   @ViewChild('select') select: NgSelectComponent;
@@ -49,12 +60,14 @@ export class BurnTokenComponent implements OnInit, AfterContentInit {
   constructor(
     private toastr: ToastrService,
     private tokenApiService: TokenApiService,
+    private accountApiService: AccountsApiService,
     private router: Router
   ) {}
 
   ngOnInit () {
     this.fetchTokens();
     this.nftName = localStorage.getItem('nftName');
+    this.getUsers();
   }
 
   ngAfterContentInit(){
@@ -83,7 +96,8 @@ export class BurnTokenComponent implements OnInit, AfterContentInit {
       selectedToken.salt,
       selectedToken.token_commitment,
       localStorage.getItem('secretkey'),
-      selectedToken.token_commitment_index
+      selectedToken.token_commitment_index,
+      this.receiverName
     ).subscribe( data => {
         this.isRequesting = false;
         this.toastr.success('Token burned successfully.');
@@ -143,6 +157,22 @@ export class BurnTokenComponent implements OnInit, AfterContentInit {
     term = term.toLocaleLowerCase();
     let itemToSearch = item.token_uri.toLowerCase();
     return itemToSearch.indexOf(term) > -1;
+  }
+
+  /**
+   * Method to retrive all users.
+   * 
+   */
+  getUsers () {
+    this.isRequesting = true;
+    this.accountApiService.getUsers().subscribe(
+      data => {
+        this.isRequesting = false;
+        this.users = data['data'];
+      }, error => {
+        this.isRequesting = false;
+        this.toastr.error('Please try again.', "Error");
+      })
   }
 
 }

--- a/ui/src/app/pages/overview/overview.component.html
+++ b/ui/src/app/pages/overview/overview.component.html
@@ -193,7 +193,7 @@
                     </td>
                     <td>{{ transaction.token_uri }}</td>
                     <td>{{ transaction.created_at | date: 'dd/MM/yyyy hh:mm:ss a' }}</td>
-                    <td>{{ transaction.transferee ? transaction.transferee : '' }}</td>
+                    <td>{{ transaction.transferee || transaction.receiver_name ? (transaction.transferee || transaction.receiver_name) : '' }}</td>
                   </tr>
                 </tbody>
               </table>

--- a/ui/src/app/pages/overview/overview.component.html
+++ b/ui/src/app/pages/overview/overview.component.html
@@ -317,7 +317,7 @@
                     <td *ngIf="transaction.type !== 'transferred'"></td>
 
                     <td>{{ transaction.timestamp | date: 'dd/MM/yyyy hh:mm:ss a' }}</td>
-                    <td *ngIf="transaction.type === 'transferred'">
+                    <td *ngIf="transaction.type === 'transferred' || transaction.type === 'burned'">
                       {{ transaction.receiver_name ? transaction.receiver_name : '' }}
                     </td>
                     <td *ngIf="transaction.type !== 'transferred'"></td>

--- a/ui/src/app/services/coins/coin-api.service.ts
+++ b/ui/src/app/services/coins/coin-api.service.ts
@@ -132,7 +132,8 @@ export class CoinApiService {
     S_A: string,
     z_A_index:string,
     z_A:string,
-    pk_A?: string,
+    pk_A: string,
+    payTo: string
   ) {
     const httpOptions = {
       headers: new HttpHeaders({ 'Content-Type': 'application/json' }),
@@ -144,7 +145,8 @@ export class CoinApiService {
       S_A,
       pk_A,
       z_A_index,
-      z_A
+      z_A,
+      payTo
     }
     const url = config.apiGateway.root + 'coin/burn';
     return this.http

--- a/ui/src/app/services/tokens/token-api.service.ts
+++ b/ui/src/app/services/tokens/token-api.service.ts
@@ -88,7 +88,7 @@ export class TokenApiService {
    * @param Sk_A {String} Secret key of Alice
    * @param z_A_index {String} Token commitment index
    */
-  burnToken(A: string, uri: string, S_A: string, z_A: string, Sk_A: string, z_A_index: number) {
+  burnToken(A: string, uri: string, S_A: string, z_A: string, Sk_A: string, z_A_index: number, payTo:string) {
     const httpOptions = {
       headers: new HttpHeaders({ 'Content-Type': 'application/json' }),
     };
@@ -98,7 +98,8 @@ export class TokenApiService {
       S_A,
       z_A,
       Sk_A,
-      z_A_index
+      z_A_index,
+      payTo
     };
     const url = config.apiGateway.root + 'token/burn';
     return this.http

--- a/zkp/src/index.js
+++ b/zkp/src/index.js
@@ -113,7 +113,7 @@ app.route('/token/transfer').post(async (req, res) => {
 });
 
 app.route('/token/burn').post(async (req, res) => {
-  const { A, S_A, Sk_A, z_A, z_A_index } = req.body;
+  const { A, S_A, Sk_A, z_A, z_A_index, payTo } = req.body;
   const { address } = req.headers;
   const response = new Response();
   try {
@@ -124,7 +124,7 @@ app.route('/token/burn').post(async (req, res) => {
       z_A,
       z_A_index,
       address,
-      address, // payed to same user.
+      payTo, // payed to same user.
     );
     response.statusCode = 200;
     response.data = {


### PR DESCRIPTION
**Earlier**:

The users could only burn off "ERC20/ERC721 token commitments" and transfer generated "ERC20/ERC721 tokens" to themselves.

**Enhancement**:

Now, The users could burn off "ERC20/ERC721 token commitments" and transfer generated "ERC20/ERC721 tokens" to themselves or other users.

  -- Added user selection option in burn page of ERC20/ERC721 token commitment (UI)
  -- Populate transferee in ERC20/ERC721 token commitment tab of overview page (UI)
  -- Passed `payTo` parameter to ZKP micro-service (backend)
  -- Saved and retrieved transferee details in transaction API of DB micro-service (backend) 

fixes#37