### PR TITLE
chore:change docker-proxy to dotdocker

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ As well as this file, please be sure to check out:
 - [SECURITY.md](./SECURITY.md) to learn about how we handle security issues.
 
 ## Security updates
-Critical security updates will be listed [here](./security-updates.md). If you had previously installed Nightfall prior to one of these security updates, please pull the latest code, and follow the extra re-installation steps.  
+
+Critical security updates will be listed [here](./security-updates.md). If you had previously
+installed Nightfall prior to one of these security updates, please pull the latest code, and follow
+the extra re-installation steps.
 
 ## Getting started
 
@@ -44,15 +47,18 @@ The Nightfall demonstration requires the following software to run:
     space (minimum - 12GB memory is better) or 16GB of memory with 512MB of swap. **The default
     values for Docker Desktop will NOT work. No, they really won't**.
 - Python
-  - Be sure npm is setup to use v2.7 of python, not python3. To check the python version, run `python --version`
-  - You may need to run `npm config set python /usr/bin/python2.7` (or wherever your python 2 location is)
+  - Be sure npm is setup to use v2.7 of python, not python3. To check the python version, run
+    `python --version`
+  - You may need to run `npm config set python /usr/bin/python2.7` (or wherever your python 2
+    location is)
 - Node (tested with node 10.15.3) with npm and node-gyp.
   - Will not work with node v12. To check the node version, run `node --version`
-  - If using mac/brew, then you may need to run `brew install node@10` and `brew link --overwrite node@10 --force`
+  - If using mac/brew, then you may need to run `brew install node@10` and
+    `brew link --overwrite node@10 --force`
 - Xcode Command line tools:
   - If running macOS, install Xcode then run `xcode-select --install` to install command line tools.
-- docker-proxy
-  - <https://github.com/aj-may/docker-proxy/>
+- dotdocker
+  - <https://github.com/aj-may/dotdocker/>
 
 ### Starting servers
 
@@ -60,9 +66,9 @@ Start Docker:
 
 - On Mac, open Docker.app.
 
-Start docker-proxy:
+Start dotdocker:
 
-- `docker-proxy start`
+- `dotdocker start`
 
 ### Installing Nightfall
 
@@ -193,10 +199,11 @@ Ganache one we provide
 ## Acknowledgements
 
 Team Nightfall thanks those who have indirectly contributed to it, with the ideas and tools that
-they have shared with the community:  
-- [ZoKrates](https://hub.docker.com/r/michaelconnor/zok)  
-- [Libsnark](https://github.com/scipr-lab/libsnark)  
-- [Zcash](https://github.com/zcash/zcash)  
+they have shared with the community:
+
+- [ZoKrates](https://hub.docker.com/r/michaelconnor/zok)
+- [Libsnark](https://github.com/scipr-lab/libsnark)
+- [Zcash](https://github.com/zcash/zcash)
 - [GM17](https://eprint.iacr.org/2017/540.pdf)
 - [0xcert](https://github.com/0xcert/ethereum-erc721/)
 - [OpenZeppelin](https://github.com/OpenZeppelin/openzeppelin-solidity/blob/master/contracts/token/ERC20/ERC20.sol)


### PR DESCRIPTION
# Description

Updates `docker-proxy` install link in README.md to `dotdocker`.

## Related Issue

Closes issue #52 

## Motivation and Context

The tool `docker-proxy` has been completely rebuilt as `dotdocker`, which supports more operating systems.

## How Has This Been Tested

Changes to the code are only in README.md. I have tested basic Nightfall functionality using `dotdocker` and have not encountered any errors. Needs additional testing **for Linux machines.** Please try testing on Linux.

## Screenshots (if appropriate)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.