### PR TITLE
fix(zkp): removed private _owner field from NFTokenShield and FTokenS…

### DIFF
--- a/zkp/contracts/FTokenShield.sol
+++ b/zkp/contracts/FTokenShield.sol
@@ -48,7 +48,6 @@ depth row  width  st#     end#
   event VerifierChanged(address newVerifierContract);
   event VkIdsChanged(bytes32 mintVkId, bytes32 transferVkId, bytes32 burnVkId);
 
-  address payable private _owner;
 
   uint constant merkleWidth = 4294967296; //2^32
   uint constant merkleDepth = 33; //33
@@ -92,7 +91,7 @@ depth row  width  st#     end#
   self destruct
   */
   function close() public onlyOwner {
-      selfdestruct(_owner);
+      selfdestruct(address(uint160(_owner)));
   }
 
   /**

--- a/zkp/contracts/NFTokenShield.sol
+++ b/zkp/contracts/NFTokenShield.sol
@@ -50,8 +50,6 @@ depth row  width  st#     end#
     event VerifierChanged(address newVerifierContract);
     event VkIdsChanged(bytes32 mintVkId, bytes32 transferVkId, bytes32 burnVkId);
 
-    address payable private _owner;
-
     uint constant merkleWidth = 4294967296; //2^32
     uint constant merkleDepth = 33; //33
 
@@ -84,7 +82,7 @@ depth row  width  st#     end#
     self destruct
     */
     function close() external onlyOwner {
-        selfdestruct(_owner);
+        selfdestruct(address(uint160(_owner)));
     }
 
     /**


### PR DESCRIPTION
# Description

Removed shadow property  `_owner` from  NFTokenShield and FTokenShield contract.
And updated the close() method, since `selfdestruct` method is expecting payable address. 
## Related Issue
NFTokenShield/FTokenShield will have two _owner variables. The modifier onlyOwner and the function transferOwnership will be performed using Ownable._owner, while close() will be performed using NFTokenShield._owner/FTokenShield._owner..

#8 
## Motivation and Context
 
To fix is for reusing the _owner field of Ownable.sol and avoid confusion

## How Has This Been Tested
  Test the code using UI
## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist


- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.