### PR TITLE
Asish.ap/moved salt generation to zkp

### DIFF
--- a/API-Gateway/src/index.js
+++ b/API-Gateway/src/index.js
@@ -6,8 +6,8 @@
 *****************************************************************************/
 
 import rootRouter from './routes/api-gateway';
-import tokenRoutes from './routes/token';
-import coinRoutes from './routes/coin';
+import nftCommitmentRoutes from './routes/nft_commitment';
+import ftCommitmentRoutes from './routes/ft_commitment';
 import ftRoutes from './routes/ft';
 import nftRoutes from './routes/nft';
 import userRoutes from './routes/user';
@@ -45,8 +45,8 @@ app.use(
 );
 app.use('/', unlockAccount, router);
 app.use('/', rootRouter);
-app.use('/token', tokenRoutes);
-app.use('/coin', coinRoutes);
+app.use('/token', nftCommitmentRoutes);
+app.use('/coin', ftCommitmentRoutes);
 app.use('/ft', ftRoutes);
 app.use('/nft', nftRoutes);
 app.use('/user', userRoutes);

--- a/API-Gateway/src/routes/ft_commitment.js
+++ b/API-Gateway/src/routes/ft_commitment.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { mintCoin, transferCoin, burnCoin, checkCorrectnessCoin } from '../services/coin';
+import { mintCoin, transferCoin, burnCoin, checkCorrectnessCoin } from '../services/ft_commitment';
 
 const router = express.Router();
 

--- a/API-Gateway/src/routes/nft_commitment.js
+++ b/API-Gateway/src/routes/nft_commitment.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { checkCorrectnessToken, mintToken, transferToken, burnToken } from '../services/token';
+import { checkCorrectnessToken, mintToken, transferToken, burnToken } from '../services/nft_commitment';
 
 const router = express.Router();
 

--- a/API-Gateway/src/services/ft_commitment.js
+++ b/API-Gateway/src/services/ft_commitment.js
@@ -47,8 +47,7 @@ export async function mintCoin(req, res, next) {
   try {
     const { data } = await zkp.mintCoin(req.user, {
       A: req.body.A,
-      pk_A: req.body.pk_A,
-      S_A: req.body.S_A,
+      pk_A: req.body.pk_A
     });
 
     data.coin_index = parseInt(data.coin_index, 16);
@@ -133,7 +132,7 @@ export async function transferCoin(req, res, next) {
     // F is the value returned as 'change' to the transferor
     await whisperTransaction(req, {
       E: req.body.E,
-      S_E: req.body.S_E,
+      S_E: data.S_E,
       pk: req.body.pk_B,
       z_E: data.z_E,
       z_E_index: data.z_E_index,

--- a/API-Gateway/src/services/nft_commitment.js
+++ b/API-Gateway/src/services/nft_commitment.js
@@ -48,15 +48,14 @@ export async function mintToken(req, res, next) {
     // mint a private 'token commitment' within the shield contract to represent the public NFToken with the specified tokenID
     const { data } = await zkp.mintToken(req.user, {
       A: req.body.tokenID,
-      pk_A: req.user.pk_A,
-      S_A: req.body.S_A,
+      pk_A: req.user.pk_A
     });
 
     // add the new token commitment (and details of its hash preimage) to the token db.
     await db.addToken(req.user, {
       A: req.body.tokenID,
       tokenUri: req.body.uri,
-      S_A: req.body.S_A,
+      S_A: data.S_A,
       z_A: data.z_A,
       z_A_index: parseInt(data.z_A_index, 16),
       is_minted: true,
@@ -128,7 +127,7 @@ export async function transferToken(req, res, next) {
       S_A: req.body.S_A,
       z_A: req.body.z_A,
       z_A_index: req.body.z_A_index,
-      S_B: req.body.S_B,
+      S_B: data.S_B,
       z_B: data.z_B,
       z_B_index: parseInt(data.z_B_index, 16),
       receiver_name: req.body.receiver_name,
@@ -141,7 +140,7 @@ export async function transferToken(req, res, next) {
       tokenUri: req.body.uri,
       A: req.body.A,
       pk: req.body.pk_B,
-      S_A: req.body.S_B,
+      S_A: data.S_B,
       z_A: data.z_B,
       z_A_index: parseInt(data.z_B_index, 16),
       transferee: req.body.receiver_name,

--- a/ui/src/app/pages/mint-coin/mint-coin.component.ts
+++ b/ui/src/app/pages/mint-coin/mint-coin.component.ts
@@ -81,11 +81,10 @@ export class MintCoinsComponent implements OnInit {
    */
   mintCoin() {
     this.isRequesting = true;
-    this.serialNumber = this.utilService.generateRandomSerial();
     var hexValue = (this.mintCoinForm.controls['A'].value).toString(16);
     var hexString = '0x' + hexValue.padStart(32,"0");
     console.log('Hexstring::',hexString);
-    this.coinApiService.mintCoin(hexString, localStorage.getItem('publickey'), this.serialNumber).subscribe(tokenDetails => {
+    this.coinApiService.mintCoin(hexString, localStorage.getItem('publickey')).subscribe(tokenDetails => {
       this.isRequesting = false;
       this.toastr.success('Coin Minted is ' + tokenDetails['data']['coin']);
       this.router.navigate(['/coin/list']);

--- a/ui/src/app/pages/mint-token/mint-token.component.ts
+++ b/ui/src/app/pages/mint-token/mint-token.component.ts
@@ -72,10 +72,9 @@ export class MintTokensComponent implements OnInit, AfterContentInit {
    * Method to mint ERC-721 token commitment.
    */
   mintToken() {
-      var serialNumber = this.utilService.generateRandomSerial();
       this.isRequesting = true;
       this.selectedToken = this.selectedTokenList[0];
-      this.tokenApiService.mintToken(serialNumber, this.selectedToken).subscribe(tokenDetails => {
+      this.tokenApiService.mintToken(this.selectedToken).subscribe(tokenDetails => {
         console.log('Token Minted is ' + tokenDetails['data']['z_A']);
         this.isRequesting = false;
         this.toastr.success('Token Minted is ' + tokenDetails['data']['z_A'].slice(0,20)+'...');

--- a/ui/src/app/pages/spend-coin/spend-coin.component.ts
+++ b/ui/src/app/pages/spend-coin/spend-coin.component.ts
@@ -163,8 +163,6 @@ export class SpendCoinComponent implements OnInit , AfterContentInit{
       coin2['salt'],
       coin1['coin_commitment_index'],
       coin2['coin_commitment_index'],
-      this.utilService.generateRandomSerial(),
-      this.utilService.generateRandomSerial(),
       coin1['coin_commitment'],
       coin2['coin_commitment'],
       localStorage.getItem('secretkey'),

--- a/ui/src/app/pages/spend-token/spend-token.component.ts
+++ b/ui/src/app/pages/spend-token/spend-token.component.ts
@@ -108,7 +108,6 @@ export class SpendTokenComponent implements OnInit, AfterContentInit {
       selectedToken.token_uri,
       selectedToken.salt,
       selectedToken.token_commitment,
-      this.utilService.generateRandomSerial(),
       localStorage.getItem('secretkey'),
       this.receiverName,
       selectedToken.token_commitment_index

--- a/ui/src/app/services/coins/coin-api.service.ts
+++ b/ui/src/app/services/coins/coin-api.service.ts
@@ -21,15 +21,14 @@ export class CoinApiService {
   * @param pk_A {String} Public key of Alice
   * @param S_A {String} Random Serial number 
   */
- mintCoin(A: string, pk_A: string, S_A: string) {
+ mintCoin(A: string, pk_A: string) {
   const httpOptions = {
     headers: new HttpHeaders({ 'Content-Type': 'application/json' }),
   };
 
   const body = {
     A: A,
-    pk_A,
-    S_A: S_A
+    pk_A
   }
 
   const url = config.apiGateway.root + 'coin/mint';
@@ -182,8 +181,6 @@ export class CoinApiService {
     S_D: string,
     z_C_index: string,
     z_D_index: string,
-    S_E: string,
-    S_F: string,
     z_C: string,
     z_D: string,
     sk_A: string,
@@ -202,8 +199,6 @@ export class CoinApiService {
       S_D,
       z_C_index,
       z_D_index,
-      S_E,
-      S_F,
       sk_A,
       z_C,
       z_D,

--- a/ui/src/app/services/tokens/token-api.service.ts
+++ b/ui/src/app/services/tokens/token-api.service.ts
@@ -21,16 +21,14 @@ export class TokenApiService {
    * 
    * Method to initiate a HTTP request to mint ERC-721 token commitment. 
    * 
-   * @param S_A {String} Random Serial number
    * @param token {String} Amount to mint
    */
-  mintToken(S_A: string, token: any) {
+  mintToken(token: any) {
     const httpOptions = {
       headers: new HttpHeaders({ 'Content-Type': 'application/json' }),
     };
 
     const body = {
-      S_A,
       uri: token.uri,
       tokenID: token.token_id,
       contractAddress: token.shield_contract_address
@@ -51,12 +49,11 @@ export class TokenApiService {
  * @param uri {String} Token name
  * @param S_A {String} Serial number of token
  * @param z_A {String} Token2 commitment 
- * @param S_B String} Serial number of token
  * @param sk_A {String} Secret key of Alice
  * @param receiver_name {String} Rceiver name
  * @param z_A_index {String} Token commitment index
  */
-  spendToken(A: string, uri: string, S_A: string, z_A: string, S_B: string, sk_A: string, receiver_name:string, z_A_index: number) {
+  spendToken(A: string, uri: string, S_A: string, z_A: string, sk_A: string, receiver_name:string, z_A_index: number) {
     const httpOptions = {
       headers: new HttpHeaders({ 'Content-Type': 'application/json' }),
     };
@@ -65,7 +62,6 @@ export class TokenApiService {
       A,
       uri,
       S_A,
-      S_B,
       sk_A,
       z_A,
       receiver_name,

--- a/zkp/src/index.js
+++ b/zkp/src/index.js
@@ -18,6 +18,8 @@ import fTokenController from './f-token-controller';
 
 config.setEnv(argv.environment);
 
+const utils = require('zkp-utils')('/app/config/stats.json');
+
 const app = express();
 
 app.use((req, res, next) => {
@@ -59,9 +61,8 @@ app.route('/vk').post(async (req, res) => {
 
 app.route('/token/mint').post(async (req, res) => {
   const { address } = req.headers;
-
-  const { A, pk_A, S_A } = req.body;
-
+  const { A, pk_A } = req.body;
+  const S_A = await utils.rndHex(27);
   const response = new Response();
 
   try {
@@ -71,6 +72,7 @@ app.route('/token/mint').post(async (req, res) => {
     response.data = {
       z_A,
       z_A_index,
+      S_A
     };
     res.json(response);
   } catch (err) {
@@ -82,7 +84,8 @@ app.route('/token/mint').post(async (req, res) => {
 });
 
 app.route('/token/transfer').post(async (req, res) => {
-  const { A, pk_B, S_A, S_B, sk_A, z_A, z_A_index } = req.body;
+  const { A, pk_B, S_A, sk_A, z_A, z_A_index } = req.body;
+  const S_B = await utils.rndHex(27);
   const { address } = req.headers;
   const response = new Response();
   try {
@@ -102,6 +105,7 @@ app.route('/token/transfer').post(async (req, res) => {
       z_B,
       z_B_index,
       txObj,
+      S_B
     };
     res.json(response);
   } catch (err) {
@@ -230,8 +234,8 @@ app
 
 app.route('/coin/mint').post(async (req, res) => {
   const { address } = req.headers;
-  const { A, pk_A, S_A } = req.body;
-
+  const { A, pk_A } = req.body;
+  const S_A = await utils.rndHex(27);
   const response = new Response();
 
   try {
@@ -240,6 +244,7 @@ app.route('/coin/mint').post(async (req, res) => {
     response.data = {
       coin,
       coin_index,
+      S_A
     };
     res.json(response);
   } catch (err) {
@@ -252,8 +257,9 @@ app.route('/coin/mint').post(async (req, res) => {
 
 app.route('/coin/transfer').post(async (req, res) => {
   const { address } = req.headers;
-  const { C, D, E, F, pk_B, S_C, S_D, S_E, S_F, sk_A, z_C, z_C_index, z_D, z_D_index } = req.body;
-
+  const { C, D, E, F, pk_B, S_C, S_D, sk_A, z_C, z_C_index, z_D, z_D_index } = req.body;
+  const S_E =  await utils.rndHex(27);
+  const S_F =  await utils.rndHex(27);
   const response = new Response();
   try {
     const { z_E, z_E_index, z_F, z_F_index, txObj } = await fController.transfer(
@@ -280,6 +286,8 @@ app.route('/coin/transfer').post(async (req, res) => {
       z_F,
       z_F_index,
       txObj,
+      S_E,
+      S_F
     };
     res.json(response);
   } catch (err) {


### PR DESCRIPTION
# Description

Moved salt generation logic of ERC20/ERC720 token commitment for Mint and Transfer from UI to ZKP microservices and reduced the dependency.

## Related Issue

## Motivation and Context

Earlier salt generation logic of ERC20/ERC720 token commitment for Mint and Transfer is placed in UI side.  To reduce that dependency and make the ZKP microservice as independent as possible, moved that logic to ZKP microservice. 

## How Has This Been Tested

Tested using UI

## Screenshots (if appropriate)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.