### PR TITLE
fix(database): NFToken listed after burn in token listing page.

### DIFF
--- a/database/src/business/token.service.js
+++ b/database/src/business/token.service.js
@@ -41,7 +41,8 @@ module.exports = class TokenService {
 			COLLECTIONS.PUBLIC_TOKEN,
 			{
 				token_id,
-				is_transferred: {$exists: false}
+				is_transferred: {$exists: false},
+				is_shielded: false
 			},
 			{ '$set': data }
 		);


### PR DESCRIPTION
# Description

Fixed ERC721 token is listed after burn in listing page.

## Related Issue

## Motivation and Context
ERC721 token is listed after burn in listing page.

**Steps to reproduce:**
1. Alice minted a NFT
2. Alice minted the same NFT to NFT commitment
3. Transfer NFT commitment to Bob
4. Bob burns that NFT commitment
5. Bob transfer NFT token to Alice
6. Alice burns that token.

Ideally after burned a NFT token, it shouldn't be appear in listing page. 
This issue is fixed by adding a shield flag when updating the NFT token.

## How Has This Been Tested

Tested via UI

## Screenshots (if appropriate)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.