### PR TITLE
fix(ui): Limit the text field to enter numbers only

### DIFF
--- a/ui/src/app/pages/burn-public-coin/burn-public-coin.component.html
+++ b/ui/src/app/pages/burn-public-coin/burn-public-coin.component.html
@@ -25,11 +25,12 @@
           <label for="name mb-1">Enter amount</label>
           <div class="row col-sm-12">
             <input
-              type="text"
+              type="number"
               class="form-control text-box"
               autoFocus
               [(ngModel)]="amount"
               (keydown)="$event.keyCode == 13 ? burnPublicCoin() : null"
+              (keypress)="utilService.validate($event)"
               placeholder="Please enter amount"
               required
             />

--- a/ui/src/app/pages/burn-public-coin/burn-public-coin.component.ts
+++ b/ui/src/app/pages/burn-public-coin/burn-public-coin.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit} from '@angular/core';
 import { ToastrService } from 'ngx-toastr';
 import { CoinApiService } from '../../services/coins/coin-api.service';
 import { Router } from '@angular/router';
+import { UtilService } from '../../services/utils/util.service';
 
 /**
  * Burn public coin component, which is used for rendering the page of burn public coin.
@@ -9,7 +10,7 @@ import { Router } from '@angular/router';
 @Component({
   selector: 'app-burn-public-coin',
   templateUrl: './burn-public-coin.component.html',
-  providers: [CoinApiService],
+  providers: [CoinApiService, UtilService],
   styleUrls: ['./burn-public-coin.component.css']
 })
 export class BurnPublicCoinComponent implements OnInit {
@@ -32,6 +33,7 @@ export class BurnPublicCoinComponent implements OnInit {
   constructor(
     private toastr: ToastrService,
     private coinApiService: CoinApiService,
+    private utilService: UtilService,
     private router: Router
   ) {
     
@@ -55,6 +57,9 @@ export class BurnPublicCoinComponent implements OnInit {
         this.toastr.error('Please try again', 'Error');      
     })
   }
+
+
+   
   
 }
 

--- a/ui/src/app/pages/mint-coin/mint-coin.component.html
+++ b/ui/src/app/pages/mint-coin/mint-coin.component.html
@@ -38,6 +38,7 @@
                   <div class="row col-sm-12">
                     <input
                       type="number"
+                      (keypress)="utilService.validate($event)"
                       autoFocus
                       class="form-control simple-text"
                       id="A"

--- a/ui/src/app/pages/mint-public-coin/mint-public-coin.component.html
+++ b/ui/src/app/pages/mint-public-coin/mint-public-coin.component.html
@@ -25,7 +25,8 @@
           <label for="name mb-1">Enter amount</label>
           <div class="row col-sm-12">
             <input
-              type="text"
+              type="number"
+              (keypress)="utilService.validate($event)"
               class="form-control text-box"
               autoFocus
               [(ngModel)]="amount"

--- a/ui/src/app/pages/mint-public-coin/mint-public-coin.component.ts
+++ b/ui/src/app/pages/mint-public-coin/mint-public-coin.component.ts
@@ -2,13 +2,14 @@ import { Component, OnInit} from '@angular/core';
 import { ToastrService } from 'ngx-toastr';
 import { CoinApiService } from '../../services/coins/coin-api.service';
 import { Router } from '@angular/router';
+import { UtilService } from '../../services/utils/util.service';
 /**
  * Mint public coin component, which is used for rendering the page of mint ERC-20 token.
  */
 @Component({
   selector: 'app-mint-public-coin',
   templateUrl: './mint-public-coin.component.html',
-  providers: [CoinApiService],
+  providers: [CoinApiService, UtilService],
   styleUrls: ['./mint-public-coin.component.css']
 })
 export class MintPublicCoinComponent implements OnInit {
@@ -31,6 +32,7 @@ export class MintPublicCoinComponent implements OnInit {
   constructor(
     private toastr: ToastrService,
     private coinApiService: CoinApiService,
+    private utilService: UtilService,
     private router: Router
   ) {
     

--- a/ui/src/app/pages/spend-public-coin/spend-public-coin.component.html
+++ b/ui/src/app/pages/spend-public-coin/spend-public-coin.component.html
@@ -25,11 +25,12 @@
           <div class="col-sm-12">
             <label for="name mb-1">Enter amount</label>
             <input
-              type="text"
+              type="number"
               class="form-control text-box"
               autoFocus
               [(ngModel)]="amount"
               (keydown)="$event.keyCode == 13 ? transferPublicCoin() : null"
+              (keypress)="utilService.validate($event)"
               placeholder="Please enter amount"
               required
             />

--- a/ui/src/app/pages/spend-public-coin/spend-public-coin.component.ts
+++ b/ui/src/app/pages/spend-public-coin/spend-public-coin.component.ts
@@ -3,6 +3,7 @@ import { ToastrService } from 'ngx-toastr';
 import { CoinApiService } from '../../services/coins/coin-api.service';
 import { AccountsApiService } from '../../services/accounts/accounts-api.service';
 import { Router } from '@angular/router';
+import { UtilService } from '../../services/utils/util.service';
 
 /**
  *  Spend public coin component, which is used for rendering the page of transfer ERC-20 token to the selected receipent.
@@ -10,7 +11,7 @@ import { Router } from '@angular/router';
 @Component({
   selector: 'app-spend-public-coin',
   templateUrl: './spend-public-coin.component.html',
-  providers: [CoinApiService, AccountsApiService],
+  providers: [CoinApiService, AccountsApiService, UtilService],
   styleUrls: ['./spend-public-coin.component.css']
 })
 export class SpendPublicCoinComponent implements OnInit {
@@ -45,6 +46,7 @@ export class SpendPublicCoinComponent implements OnInit {
     private toastr: ToastrService,
     private coinApiService: CoinApiService,
     private accountApiService: AccountsApiService,
+    private utilService: UtilService,
     private router: Router
   ) {
     

--- a/ui/src/app/services/utils/util.service.ts
+++ b/ui/src/app/services/utils/util.service.ts
@@ -32,5 +32,21 @@ export class UtilService {
   convertToNumber (hex: string) {
     return Number(hex);
   }
+
+  validate(evt) {
+    let theEvent = evt || window.event;
+    let key;
+    if (theEvent.type === 'paste') { // Handle paste
+        key = evt.clipboardData.getData('text/plain');
+    } else {// Handle key press
+        key = theEvent.keyCode || theEvent.which;
+        key = String.fromCharCode(key);
+    }
+    var regex = /[0-9]|\./;
+    if( !regex.test(key) ) {
+      theEvent.returnValue = false;
+      if(theEvent.preventDefault) theEvent.preventDefault();
+    }
+  }
   
 }


### PR DESCRIPTION

# Description

Limit the text field to enter numbers only in mint, burn, transfer of ERC20 token pages.

## Motivation and Context

Using UI if user entered characters instead of numbers when Mint, Transfer, Burn of ERC20 token it will hang and get the following error on terminal

```
zkp_1               | { Error: invalid number value (arg="_amount", coderType="uint256", value="ksdfg")
zkp_1               |     at Object.throwError (/app/node_modules/web3-eth-abi/node_modules/ethers/utils/errors.js:68:17)
zkp_1               |     at CoderNumber.encode (/app/node_modules/web3-eth-abi/node_modules/ethers/utils/abi-coder.js:353:20)
zkp_1               |     at /app/node_modules/web3-eth-abi/node_modules/ethers/utils/abi-coder.js:605:59
zkp_1               |     at Array.forEach (<anonymous>)
zkp_1           
```

To fix this issue make the text field limited to numbers only.

## How Has This Been Tested

Tested using UI

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.