### PR TITLE
Restrict user name field to lower case while registering.

### DIFF
--- a/ui/src/app/pages/create-accounts/create-accounts.component.html
+++ b/ui/src/app/pages/create-accounts/create-accounts.component.html
@@ -19,6 +19,7 @@
           type="text"
           placeholder="Your full name"
           class="input-field"
+          (keypress)="utilService.allowLowercase($event)"
           formControlName="accountName"
         />
         <input type="email" placeholder="Enter email" class="input-field" formControlName="email" />

--- a/ui/src/app/pages/create-accounts/create-accounts.component.ts
+++ b/ui/src/app/pages/create-accounts/create-accounts.component.ts
@@ -4,6 +4,7 @@ import { AccountsApiService } from '../../services/accounts/accounts-api.service
 import { HttpErrorResponse } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
+import { UtilService } from '../../services/utils/util.service';
 
 /**
  * Componenet to create new accounts.
@@ -11,7 +12,7 @@ import { ToastrService } from 'ngx-toastr';
 @Component({
   selector: 'app-create-accounts',
   templateUrl: './create-accounts.component.html',
-  providers: [ AccountsApiService],
+  providers: [ AccountsApiService, UtilService],
   styleUrls: ['./create-accounts.component.css']
 })
 export class CreateAccountsComponent implements OnInit {
@@ -28,7 +29,8 @@ export class CreateAccountsComponent implements OnInit {
       private fb: FormBuilder, 
       private APIservice: AccountsApiService, 
       private router: Router,
-      private toastr: ToastrService) {
+      private toastr: ToastrService,
+      private utilService: UtilService) {
    }
 
    ngOnInit() {

--- a/ui/src/app/services/utils/util.service.ts
+++ b/ui/src/app/services/utils/util.service.ts
@@ -48,5 +48,22 @@ export class UtilService {
       if(theEvent.preventDefault) theEvent.preventDefault();
     }
   }
+
+  allowLowercase(evt){
+    let theEvent = evt || window.event;
+    let key;
+    if (theEvent.type === 'paste') { // Handle paste
+        key = evt.clipboardData.getData('text/plain');
+    } else {// Handle key press
+        key = theEvent.keyCode || theEvent.which;
+        key = String.fromCharCode(key);
+    }
+    var regex = /^[a-z]+$/;
+    if( !regex.test(key) ) {
+      theEvent.returnValue = false;
+      if(theEvent.preventDefault) theEvent.preventDefault();
+    }
+  }
+
   
 }


### PR DESCRIPTION
# Description

Restrict user name field to lower case letters when creating a new account

## Related Issue
#76 
## Motivation and Context

Throwing 500 internal server error when creating a user with capital letters. Internally in nightfall we are dynamically creating collections based on user name. Every user have their own collections and collections name would be prefixed with his/her username. We observed that mongo does n't allow to create collection name with capital letters and it automatically changes the name to lower case. So during the account creation we are applying ACL to the mongo collections based on user name and mongo could n't recognise the collection name with small letters.

As a solution will restrict to lower case letters in user name field from the UI.

## How Has This Been Tested

Tested using UI

## Screenshots (if appropriate)

## Types of changes


- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.