### PR TITLE
Remove redundant mkdir

### DIFF
--- a/API-Gateway/Dockerfile
+++ b/API-Gateway/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:11.15
 
-RUN mkdir /app
 WORKDIR /app
 
 COPY ./package.json ./package-lock.json ./

--- a/accounts/Dockerfile
+++ b/accounts/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:11.15
 
-RUN mkdir /app
 WORKDIR /app
 
 COPY ./package.json ./package-lock.json ./

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:11.15
 
-RUN mkdir /app
 WORKDIR /app
 
 # Install Mongo

--- a/offchain/Dockerfile
+++ b/offchain/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:11.15
 
-RUN mkdir /app
 WORKDIR /app
 
 COPY ./package.json ./package-lock.json ./

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:11.15
 
-RUN mkdir /app
 WORKDIR /app
 
 COPY ./package.json ./package-lock.json ./

--- a/zkp/Dockerfile
+++ b/zkp/Dockerfile
@@ -1,6 +1,5 @@
 FROM node:11.15
 
-RUN mkdir /app
 WORKDIR /app
 
 COPY ./package.json ./package-lock.json ./


### PR DESCRIPTION
> The WORKDIR instruction sets the working directory for any RUN, CMD, ENTRYPOINT, COPY and ADD instructions that follow it in the Dockerfile. If the WORKDIR doesn’t exist, it will be created even if it’s not used in any subsequent Dockerfile instruction.
> 
> Source https://docs.docker.com/engine/reference/builder/

Therefore it is unnecessary to have a `mkdir` before the `WORKDIR`.