### PR TITLE
[WIP] Remove dot docker dependency for non-developers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,6 @@ The Nightfall demonstration requires the following software to run:
     `brew link --overwrite node@10 --force`
 - Xcode Command line tools:
   - If running macOS, install Xcode then run `xcode-select --install` to install command line tools.
-- dotdocker
-  - <https://github.com/aj-may/dotdocker/>
 
 ### Starting servers
 
@@ -123,7 +121,7 @@ and wait until you see the message `Compiled successfully` in the console.
 This brings up each microservice using docker-compose and finally builds a UI running on a local
 Angular server.
 
-Navigate your web browser to <http://nightfall.docker> to start using Nightfall (give everything
+Navigate your web browser to <http://localhost:8000> to start using Nightfall (give everything
 enough time to start up). There are instructions on how to use the application in the
 [UI.md](./UI.md) file.
 
@@ -144,6 +142,16 @@ volumes, and images created by up, using
 ```sh
 docker-compose down -v
 ```
+
+## Developing Nightfall
+
+Making changes to Nightfall, and some testing tasks, will require additional prerequesites and more explanaton.
+
+### Development prerequesites
+
+**dotdocker** will allow you to easily connect to individual modules within the Nightfall application when they are run from Docker. Note: when running commands from inside Docker (e.g. `docker-compose up`) the modules are able to communicate with each other using unqualified hostnames like `api-gateway`. If you will be running code directly on your development machine rather than using Docker then you will be responsible for connecting services to each other and there may be contention for ports (since you can't run three web servers on port 80 on the same development machine).
+
+- <https://github.com/aj-may/dotdocker/>
 
 ### To run zkp service unit tests
 

--- a/doc/whitepaper/application/smartContracts.tex
+++ b/doc/whitepaper/application/smartContracts.tex
@@ -162,13 +162,13 @@ See \hyperref[fig:trustedSetup]{Trusted Setup} for an explanation of deployment 
 		\begin{tabular}{lp{14cm}}
 			\texttt{./zkp/contracts/} & Contracts in Nightfall\\
 			\texttt{./zkp/migrations/} & Default deployment ordering of contracts in Nightfall\\
-			\url{http://eips.ethereum.org/EIPS/eip-165} & EIP-165\\
-			\url{http://eips.ethereum.org/EIPS/eip-20} & EIP-20\\
-			\url{http://eips.ethereum.org/EIPS/eip-721} & EIP-721\\
-			\url{http://eips.ethereum.org/EIPS/eip-196} & EIP-196\\
-			\url{http://eips.ethereum.org/EIPS/eip-197} & EIP-197\\
-			\url{http://eips.ethereum.org/EIPS/eip-1922} & EIP-1922\\
-			\url{http://eips.ethereum.org/EIPS/eip-1923} & EIP-1923
+			\url{https://eips.ethereum.org/EIPS/eip-165} & EIP-165\\
+			\url{https://eips.ethereum.org/EIPS/eip-20} & EIP-20\\
+			\url{https://eips.ethereum.org/EIPS/eip-721} & EIP-721\\
+			\url{https://eips.ethereum.org/EIPS/eip-196} & EIP-196\\
+			\url{https://eips.ethereum.org/EIPS/eip-197} & EIP-197\\
+			\url{https://eips.ethereum.org/EIPS/eip-1922} & EIP-1922\\
+			\url{https://eips.ethereum.org/EIPS/eip-1923} & EIP-1923
 		\end{tabular}
 	\end{mdframed}
 \end{center}

--- a/doc/whitepaper/application/zokrates.tex
+++ b/doc/whitepaper/application/zokrates.tex
@@ -63,7 +63,7 @@ Nightfall doesn't use the hard-coded \texttt{verifier.sol} contracts which are c
       \url{https://github.com/EYBlockchain/zokrates-preprocessor} & how to manually transpile from \texttt{.pcode} to \texttt{.code}\\ 
       \texttt{./zkp/code/README-manual-trusted-setup.md} & how to manually do the trusted setup\\
       \texttt{./zkp/contracts/GM17.sol} & for the EIP1922 Verifier contract.\\
-      \url{http://eips.ethereum.org/EIPS/eip-1922} & for the draft zk-SNARK Verifier Standard.
+      \url{https://eips.ethereum.org/EIPS/eip-1922} & for the draft zk-SNARK Verifier Standard.
     \end{tabular}
   \end{mdframed}
 \end{center}

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -17,7 +17,7 @@ services:
     networks: 
       - test_net
 
-  api-gateway_test:
+  api-gateway-test:
     build:
       context: ./API-Gateway
       dockerfile: Dockerfile
@@ -27,7 +27,7 @@ services:
       - ./api-gateway/.babelrc:/app/.babelrc
     environment:
       - NODE_ENV=test
-      - VIRTUAL_HOST=api-test.nightfall.docker
+      - VIRTUAL_HOST=api-gateway-test.nightfall.docker
     networks: 
       - test_net
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
     volumes:
       - ./api-gateway/src:/app/src
       - ./api-gateway/.babelrc:/app/.babelrc
+    ports:
+      - "8001:80"
     environment:
       VIRTUAL_HOST: api.nightfall.docker
 
@@ -76,6 +78,8 @@ services:
       - ./ui/src:/app/src
       - ./ui/angular.json:/app/angular.json
       - ./ui/tsconfig.json:/app/tsconfig.json
+    ports:
+      - "8000:80"
     environment:
       VIRTUAL_HOST: nightfall.docker
 

--- a/integration-test/config/test.json
+++ b/integration-test/config/test.json
@@ -1,4 +1,4 @@
 {
-	"apiServerURL": "http://api-test.nightfall.docker",
+	"apiServerURL": "http://api-gateway-test",
   "HASHLENGTH": 27
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,7 @@
   "main": "main.ts",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --host=0.0.0.0 --port 80 --publicHost=nightfall",
+    "start": "ng serve --host=0.0.0.0 --port 80 --publicHost=localhost",
     "build": "ng build --prod",
     "compodoc": "npx compodoc -p src/tsconfig.app.json",
     "test": "ng test",

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,7 @@
   "main": "main.ts",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --host=0.0.0.0 --port 80 --publicHost=nightfall.docker",
+    "start": "ng serve --host=0.0.0.0 --port 80 --publicHost=nightfall",
     "build": "ng build --prod",
     "compodoc": "npx compodoc -p src/tsconfig.app.json",
     "test": "ng test",

--- a/ui/src/environments/environment.ts
+++ b/ui/src/environments/environment.ts
@@ -7,5 +7,5 @@
  */
 export const environment = {
   production: false,
-  url: 'http://api.nightfall.docker/'
+  url: 'api-gateway'
 };

--- a/ui/src/environments/environment.ts
+++ b/ui/src/environments/environment.ts
@@ -7,5 +7,5 @@
  */
 export const environment = {
   production: false,
-  url: 'api-gateway'
+  url: 'http://localhost:8001/'
 };

--- a/zkp/README.md
+++ b/zkp/README.md
@@ -1,1 +1,25 @@
-# Nightfall ZKP Service
+# Nightfall Zero-Knowledge Proof Service
+
+*This module is part of Nightfall. Most users will only be interested in using the application as a whole, we direct those readers to [the main README](../README.md). This file provides additional information on how this module works so you can learn about, tinker and develop it.*
+
+This module is responsbile for generating cryptographic key pairs which, relying on the magic of zk-SNARKs, allow one party to perform a computation and another to confirm it while minimizing information flow from the former to the latter. Nightfall exploits this to allow transfer of tokens while hiding the origin, destination, and even identity(!) of these tokens.
+
+## Tasks you can perform
+
+### Generate key pairs
+
+You will need key pairs to run the full application. And the `zkp-demo` script does indeed perform this step as part of the demonstration. Generating the key pairs uses randomness as an input, so every time you generate, the pairs will be different. **If you are attaching Nightfall to an existing deployment then you will import those keys and you will NOT want to generate your own key pairs** since yours would be incompatible with the deployed applicaition.
+
+:warning: This task will take approximately one to three hours depending on your machine.
+
+From the `zkp` folder, simply run:
+
+```sh 
+docker build .
+```
+
+
+
+* Generate key pairs
+* 
+  * Run `docker `


### PR DESCRIPTION
# Description

This remove the dependency on dot docker for users that simply wish to run or deploy the app without developing it.

## Related Issue

#90

## Motivation and Context

The additional step of installing dot docker requires each user to provide root access on their computer to a script that is not well known.

## How Has This Been Tested

Follow install steps in the README.md to spin up UI.

## Screenshots (if appropriate)

n/a

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

---

# Discussion

Port 8000 is set as the canonical port for the web UI, configurable in docker-compose.yml.

Port 8001 is set as the canonical port for the API, configurable in docker-compose.yml.

# To-do

- [ ] I do not understand the configuration in protractor.conf.js and there is a hard coded port 4200 in there. 
- [ ] Angular was previously configured with `    "start": "ng serve --host=0.0.0.0 --port 80 --publicHost=nightfall",` This is updated in this PR. However it may be better to improve further by removing the `publicHost` parameter altogether.