### PR TITLE
fix(zkp): added nullifier overflow prevention to shield contracts

### DIFF
--- a/security-updates.md
+++ b/security-updates.md
@@ -40,3 +40,14 @@ Critical security updates will be listed here (ordered newest to oldest). If you
 `docker-compose build zkp`  
 
 ---
+
+
+**date**: 2019-07-29  
+**description**: Check for overflow of nullifiers  
+**tag \#**: n/a  
+**PR \#**: [#96](https://github.com/EYBlockchain/nightfall/pull/96)  
+**issue \#**: [#95](https://github.com/EYBlockchain/nightfall/issues/95)  
+**re-installation**:  
+`docker-compose build zkp`  
+
+---

--- a/zkp/contracts/FTokenShield.sol
+++ b/zkp/contracts/FTokenShield.sol
@@ -51,8 +51,8 @@ depth row  width  st#     end#
 
   uint constant merkleWidth = 4294967296; //2^32
   uint constant merkleDepth = 33; //33
-
   uint private balance = 0;
+  uint256 constant zokratesPrime = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
 
   mapping(bytes27 => bytes27) public ns; //store nullifiers of spent commitments
   mapping(bytes27 => bytes27) public zs; //array holding the commitments.  Basically the bottom row of the merkle tree
@@ -171,6 +171,11 @@ depth row  width  st#     end#
     bytes27 zf = packedToBytes27(_inputs[7], _inputs[6]);
     bytes27 inputRoot = packedToBytes27(_inputs[9],_inputs[8]);
 
+    //checks to prevent a ZoKrates overflow attack
+    require(_inputs[0]<zokratesPrime, "Input too large - possible overflow attack");
+    require(_inputs[1]<zokratesPrime, "Input too large - possible overflow attack");
+    require(_inputs[2]<zokratesPrime, "Input too large - possible overflow attack");
+    require(_inputs[3]<zokratesPrime, "Input too large - possible overflow attack");
 
     require(roots[inputRoot] == inputRoot, "The input root has never been the root of the Merkle Tree");
     require(nc != nd, "The nullifiers nc and nd must be different!");
@@ -213,6 +218,10 @@ depth row  width  st#     end#
     uint256 value = _inputs[2]; //the coin value being cashed-out
     bytes27 nc = packedToBytes27(_inputs[4], _inputs[3]); //recover the nullifier
     bytes27 inputRoot = packedToBytes27(_inputs[6], _inputs[5]); //recover the root
+
+    //checks to prevent a ZoKrates overflow attack
+    require(_inputs[3]<zokratesPrime, "Input too large - possible overflow attack");
+    require(_inputs[4]<zokratesPrime, "Input too large - possible overflow attack");
 
     require(roots[inputRoot] == inputRoot, "The input root has never been the root of the Merkle Tree");
     require(ns[nc]==0, "The token has already been nullified!");

--- a/zkp/contracts/FTokenShield.sol
+++ b/zkp/contracts/FTokenShield.sol
@@ -161,6 +161,12 @@ depth row  width  st#     end#
 
     require(_vkId == transferVkId, "Incorrect vkId");
 
+    //checks to prevent a ZoKrates overflow attack
+    require(_inputs[0]<zokratesPrime, "Input too large - possible overflow attack");
+    require(_inputs[1]<zokratesPrime, "Input too large - possible overflow attack");
+    require(_inputs[2]<zokratesPrime, "Input too large - possible overflow attack");
+    require(_inputs[3]<zokratesPrime, "Input too large - possible overflow attack");
+
     // verify the proof
     bool result = verifier.verify(_proof, _inputs, _vkId);
     require(result, "The proof has not been verified by the contract");
@@ -170,12 +176,6 @@ depth row  width  st#     end#
     bytes27 ze = packedToBytes27(_inputs[5], _inputs[4]);
     bytes27 zf = packedToBytes27(_inputs[7], _inputs[6]);
     bytes27 inputRoot = packedToBytes27(_inputs[9],_inputs[8]);
-
-    //checks to prevent a ZoKrates overflow attack
-    require(_inputs[0]<zokratesPrime, "Input too large - possible overflow attack");
-    require(_inputs[1]<zokratesPrime, "Input too large - possible overflow attack");
-    require(_inputs[2]<zokratesPrime, "Input too large - possible overflow attack");
-    require(_inputs[3]<zokratesPrime, "Input too large - possible overflow attack");
 
     require(roots[inputRoot] == inputRoot, "The input root has never been the root of the Merkle Tree");
     require(nc != nd, "The nullifiers nc and nd must be different!");
@@ -209,6 +209,10 @@ depth row  width  st#     end#
 
     require(_vkId == burnVkId, "Incorrect vkId");
 
+    //checks to prevent a ZoKrates overflow attack
+    require(_inputs[3]<zokratesPrime, "Input too large - possible overflow attack");
+    require(_inputs[4]<zokratesPrime, "Input too large - possible overflow attack");
+
     // verify the proof
     bool result = verifier.verify(_proof, _inputs, _vkId);
     require(result, "The proof has not been verified by the contract");
@@ -218,10 +222,6 @@ depth row  width  st#     end#
     uint256 value = _inputs[2]; //the coin value being cashed-out
     bytes27 nc = packedToBytes27(_inputs[4], _inputs[3]); //recover the nullifier
     bytes27 inputRoot = packedToBytes27(_inputs[6], _inputs[5]); //recover the root
-
-    //checks to prevent a ZoKrates overflow attack
-    require(_inputs[3]<zokratesPrime, "Input too large - possible overflow attack");
-    require(_inputs[4]<zokratesPrime, "Input too large - possible overflow attack");
 
     require(roots[inputRoot] == inputRoot, "The input root has never been the root of the Merkle Tree");
     require(ns[nc]==0, "The token has already been nullified!");

--- a/zkp/contracts/NFTokenShield.sol
+++ b/zkp/contracts/NFTokenShield.sol
@@ -173,6 +173,10 @@ depth row  width  st#     end#
 
         require(_vkId == transferVkId, "Incorrect vkId");
 
+        //checks to prevent a ZoKrates overflow attack
+        require(_inputs[0]<zokratesPrime, "Input too large - possible overflow attack");
+        require(_inputs[1]<zokratesPrime, "Input too large - possible overflow attack");
+
         // verify the proof
         bool result = verifier.verify(_proof, _inputs, _vkId);
         require(result, "The proof has not been verified by the contract");
@@ -180,10 +184,6 @@ depth row  width  st#     end#
         bytes27 n = packedToBytes27(_inputs[1],_inputs[0]);
         bytes27 inputRoot = packedToBytes27(_inputs[3],_inputs[2]);
         bytes27 z = packedToBytes27(_inputs[5],_inputs[4]);
-
-        //checks to prevent a ZoKrates overflow attack
-        require(_inputs[0]<zokratesPrime, "Input too large - possible overflow attack");
-        require(_inputs[1]<zokratesPrime, "Input too large - possible overflow attack");
 
         require(ns[n] == 0, "The token has already not been nullified!");
         require(roots[inputRoot] == inputRoot, "The input root has never been the root of the Merkle Tree");
@@ -208,6 +208,10 @@ depth row  width  st#     end#
 
       require(_vkId == burnVkId, "Incorrect vkId");
 
+      //checks to prevent a ZoKrates overflow attack
+      require(_inputs[4]<zokratesPrime, "Input too large - possible overflow attack");
+      require(_inputs[5]<zokratesPrime, "Input too large - possible overflow attack");
+
       // verify the proof
       bool result = verifier.verify(_proof, _inputs, _vkId);
       require(result, "The proof has not been verified by the contract");
@@ -217,10 +221,6 @@ depth row  width  st#     end#
       uint256 tokenId = combineUint256(_inputs[3], _inputs[2]); //recover the tokenId
       bytes27 na = packedToBytes27(_inputs[5], _inputs[4]); //recover the nullifier
       bytes27 inputRoot = packedToBytes27(_inputs[7], _inputs[6]); //recover the root
-
-      //checks to prevent a ZoKrates overflow attack
-      require(_inputs[4]<zokratesPrime, "Input too large - possible overflow attack");
-      require(_inputs[5]<zokratesPrime, "Input too large - possible overflow attack");
 
       require(roots[inputRoot] == inputRoot, "The input root has never been the root of the Merkle Tree");
       require(ns[na]==0, "The token has already been nullified!");

--- a/zkp/contracts/NFTokenShield.sol
+++ b/zkp/contracts/NFTokenShield.sol
@@ -52,6 +52,7 @@ depth row  width  st#     end#
 
     uint constant merkleWidth = 4294967296; //2^32
     uint constant merkleDepth = 33; //33
+    uint256 constant zokratesPrime = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
 
     mapping(bytes27 => bytes27) public ns; //store nullifiers of spent commitments
     mapping(bytes27 => bytes27) public zs; //array holding the commitments.  Basically the bottom row of the merkle tree
@@ -180,6 +181,10 @@ depth row  width  st#     end#
         bytes27 inputRoot = packedToBytes27(_inputs[3],_inputs[2]);
         bytes27 z = packedToBytes27(_inputs[5],_inputs[4]);
 
+        //checks to prevent a ZoKrates overflow attack
+        require(_inputs[0]<zokratesPrime, "Input too large - possible overflow attack");
+        require(_inputs[1]<zokratesPrime, "Input too large - possible overflow attack");
+
         require(ns[n] == 0, "The token has already not been nullified!");
         require(roots[inputRoot] == inputRoot, "The input root has never been the root of the Merkle Tree");
 
@@ -212,6 +217,10 @@ depth row  width  st#     end#
       uint256 tokenId = combineUint256(_inputs[3], _inputs[2]); //recover the tokenId
       bytes27 na = packedToBytes27(_inputs[5], _inputs[4]); //recover the nullifier
       bytes27 inputRoot = packedToBytes27(_inputs[7], _inputs[6]); //recover the root
+
+      //checks to prevent a ZoKrates overflow attack
+      require(_inputs[4]<zokratesPrime, "Input too large - possible overflow attack");
+      require(_inputs[5]<zokratesPrime, "Input too large - possible overflow attack");
 
       require(roots[inputRoot] == inputRoot, "The input root has never been the root of the Merkle Tree");
       require(ns[na]==0, "The token has already been nullified!");


### PR DESCRIPTION
# Description

Shield contracts now check that nullifier public inputs are smaller than the prime field used by ZoKrates.  This prevents the following double spend attack where `nullifier_hash + 21888242871839275222246405745257275088548364400416034343698204186575808495617 = nullifier_hash mod 218.....617` will pass snark proof verification if it fits into uint256 but will not be in the list of nullifiers held by the shield contract, allowing double spend.

## Related Issue

fixes #95

## Motivation and Context

Prevents a type of double spend attack

## How Has This Been Tested

This was tested using the ./zkp-demo-test script.

## Screenshots (if appropriate)

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.