### PR TITLE
zkp-utils dependencies installation using 'npm ci'

### DIFF
--- a/nightfall
+++ b/nightfall
@@ -25,7 +25,7 @@ docker pull michaelconnor/zok:2Jan2019
 
 printf "${GREEN}*** Installing zkp-util dependencies"
 pushd zkp-utils
-npm install
+npm ci
 popd
 
 printf "${GREEN}*** Launching containerized ganache ***${NC}\n"

--- a/nightfall-test
+++ b/nightfall-test
@@ -31,7 +31,7 @@ npm ci
 
 printf "${GREEN}*** Installing zkp-util dependencies"
 pushd zkp-utils
-npm install
+npm ci
 popd
 
 printf "${GREEN}*** Launching containerized ganache-test ***${NC}\n"


### PR DESCRIPTION
# Description
run 'npm ci' instead of 'npm i', thus use package-lock.json to install dependencies

## Related Issue
fixes#110

## Motivation and Context

avoid changes package-lock.json if dependent module have updated versions 

## How Has This Been Tested

1. by running integration test
2. and by using UI.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.