### PR TITLE
Remove redundant rm -rf node_modules

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 # Exit script as soon as a command fails.
 set -o errexit
 
-cd zkp-utils && rm -rf node_modules && npm ci && \
-cd ../account-utils && rm -rf node_modules && npm ci && \
-cd ../zkp && rm -rf node_modules && npm ci && \
+cd zkp-utils && npm ci && \
+cd ../account-utils && npm ci && \
+cd ../zkp && npm ci && \
 npm run setup-all && cd ../


### PR DESCRIPTION
# Description

This remove the redundant `rm -rf node_modules` steps that precede `npm ci`.

<!--- Describe your changes in detail -->

## Related Issue

#130 Step rm -rf node_modules is redundant

## Motivation and Context

Simplification improves readability.

## How Has This Been Tested

Ran install.sh

## Screenshots (if appropriate)

n/a

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.