### PR TITLE
explicit removal volume and network when integration test ends

### DIFF
--- a/nightfall-test
+++ b/nightfall-test
@@ -71,10 +71,14 @@ docker-compose -f docker-compose.test.yml down -v || {
   # nightfall_test_net network have no dependency left.
   sleep 3
 
-  networkID="$(docker network ls --filter name=nightfall_test_net --quiet)"
-  # removing network just in case docker-compose down haven't done the job.
-  printf "${GREEN}*** Remove test-net network if not removed ***${NC}\n"
-  [ -z "$networkID" ] && true || docker network rm nightfall_test_net
+  printf "${GREEN}*** Remove network ***${NC}\n"
+  docker network rm nightfall_test_net
+
+  printf "${GREEN}*** Remove mongo volume ***${NC}\n"
+  docker volume rm nightfall_mongo_volume_test
+
+  printf "${GREEN}*** Remove zkp-code volume ***${NC}\n"
+  docker volume rm nightfall_zkp_code_test
 }
 
 


### PR DESCRIPTION


# Description
Remove volume and network if 'docker-compose down' failed to do so

## Related Issue
fixes#155

## How Has This Been Tested
1. Integration test
2. by running UI

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.