### PR TITLE
Always use string for port numbers

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -38,7 +38,7 @@ services:
       OFFCHAIN_HOST: http://offchain_test
       OFFCHAIN_PORT: 80
     ports:
-      - '8001:80'
+      - "8001:80"
     networks:
       - test_net
 
@@ -96,7 +96,7 @@ services:
     image: trufflesuite/ganache-cli:latest
     command: ganache-cli --accounts=10 --defaultBalanceEther=1000
     ports:
-      - 8546:8545
+      - "8546:8545"
     networks:
       - test_net
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - ./api-gateway/src:/app/src
       - ./api-gateway/.babelrc:/app/.babelrc
     ports:
-      - '8001:80'
+      - "8001:80"
     environment:
       ACCOUNTS_HOST: http://accounts
       ACCOUNTS_PORT: 80
@@ -94,13 +94,13 @@ services:
       - ./ui/angular.json:/app/angular.json
       - ./ui/tsconfig.json:/app/tsconfig.json
     ports:
-      - '8000:80'
+      - "8000:80"
 
   ganache:
     image: trufflesuite/ganache-cli:latest
     command: ganache-cli --accounts=10 --defaultBalanceEther=1000
     ports:
-      - 8545:8545
+      - "8545:8545"
 
   database:
     build:


### PR DESCRIPTION
# Description

Switch to always use port numbers specified as strings in Docker Compose.

## Related Issue

#162 Always specify port numbers as strings

## Motivation and Context

This is an official Docker Compose recommendation as cited above.

## How Has This Been Tested

Ran Docker build.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Discussion

Personally, I like to collect a large bibliography for things like this where we will recognize best practices and style guides. You can see an example at https://github.com/fulldecent/aion-aip040#references

I have cited the reference in the related issue above and will be happy to maintain a references list if we will add it to this project.

