### PR TITLE
Pull out getters (Dependent on #245)

### DIFF
--- a/zkp/src/contractUtils.js
+++ b/zkp/src/contractUtils.js
@@ -1,0 +1,38 @@
+import contract from 'truffle-contract';
+import jsonfile from 'jsonfile';
+import Web3 from 'web3';
+import config from 'config';
+
+const web3 = new Web3(
+  Web3.givenProvider || new Web3.providers.HttpProvider(config.get('web3ProviderURL')),
+);
+
+const contractMapping = {
+  NFTokenShield: './build/contracts/NFTokenShield.json',
+  VerifierRegistry: './build/contracts/Verifier_Registry.json',
+  Verifier: './build/contracts/GM17_v0.json',
+  NFTokenMetadata: './build/contracts/NFTokenMetadata.json',
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export async function getContract(contractName) {
+  if (!contractMapping[contractName]) {
+    throw new Error('Unknown contract type in getContract');
+  }
+  const contractInstance = contract(jsonfile.readFileSync(contractMapping[contractName]));
+  contractInstance.setProvider(web3.currentProvider);
+  const deployed = await contractInstance.deployed();
+  return deployed;
+}
+
+export async function getVkId(actionName) {
+  const vkIds = await new Promise((resolve, reject) =>
+    jsonfile.readFile(config.get('VK_IDS'), (err, data) => {
+      // doesn't natively support promises
+      if (err) reject(err);
+      else resolve(data);
+    }),
+  );
+  const { vkId } = vkIds[actionName];
+  return vkId;
+}

--- a/zkp/src/contractUtils.js
+++ b/zkp/src/contractUtils.js
@@ -1,28 +1,28 @@
 import contract from 'truffle-contract';
 import jsonfile from 'jsonfile';
-import Web3 from 'web3';
 import config from 'config';
+import Web3 from './web3';
 
-const web3 = new Web3(
-  Web3.givenProvider || new Web3.providers.HttpProvider(config.get('web3ProviderURL')),
-);
+const web3 = Web3.connect();
 
 const contractMapping = {
   NFTokenShield: './build/contracts/NFTokenShield.json',
-  VerifierRegistry: './build/contracts/Verifier_Registry.json',
-  Verifier: './build/contracts/GM17_v0.json',
   NFTokenMetadata: './build/contracts/NFTokenMetadata.json',
+  FTokenShield: './build/contracts/FTokenShield.json',
+  FToken: './build/contracts/FToken.json',
+  Verifier: './build/contracts/GM17_v0.json',
+  VerifierRegistry: './build/contracts/Verifier_Registry.json',
 };
 
-// eslint-disable-next-line import/prefer-default-export
 export async function getContract(contractName) {
   if (!contractMapping[contractName]) {
     throw new Error('Unknown contract type in getContract');
   }
-  const contractInstance = contract(jsonfile.readFileSync(contractMapping[contractName]));
-  contractInstance.setProvider(web3.currentProvider);
+  const contractJson = jsonfile.readFileSync(contractMapping[contractName]);
+  const contractInstance = contract(contractJson);
+  contractInstance.setProvider(web3);
   const deployed = await contractInstance.deployed();
-  return deployed;
+  return { contractInstance: deployed, contractJson };
 }
 
 export async function getVkId(actionName) {

--- a/zkp/src/f-token-controller.js
+++ b/zkp/src/f-token-controller.js
@@ -203,7 +203,7 @@ knows S_A,pkA,n and n so could in fact calculate the token themselves.
 This is required for later transfers/joins so that Alice knows which 'chunks' of the Merkle Tree
 she needs to 'get' from the fTokenShield contract in order to calculate a path.
 */
-async function mint(A, pkA, S_A, account) {
+async function mint(A, pkA, S_A, vkId, account) {
   console.group('\nIN MINT...');
 
   console.log('Finding the relevant Shield and Verifier contracts');
@@ -213,17 +213,6 @@ async function mint(A, pkA, S_A, account) {
   console.log('FTokenShield contract address:', fTokenShield.address);
   console.log('Verifier contract address:', verifier.address);
   console.log('VerifierRegistry contract address:', verifierRegistry.address);
-
-  // get the Mint vkId
-  console.log('Reading vkIds from json file...');
-  const vkIds = await new Promise((resolve, reject) =>
-    jsonfile.readFile(config.VK_IDS, (err, data) => {
-      // doesn't natively support promises
-      if (err) reject(err);
-      else resolve(data);
-    }),
-  );
-  const { vkId } = vkIds.MintCoin;
 
   // Calculate new arguments for the proof:
   const zA = utils.concatenateThenHash(A, pkA, S_A);
@@ -315,6 +304,7 @@ async function transfer(
   outputCommitments,
   receiverPublicKey,
   senderSecretKey,
+  vkId,
   account,
 ) {
   const { value: C, salt: S_C, commitment: zC, index: zCIndex } = inputCommitments[0];
@@ -338,17 +328,6 @@ async function transfer(
   console.log('FTokenShield contract address:', fTokenShield.address);
   console.log('Verifier contract address:', verifier.address);
   console.log('VerifierRegistry contract address:', verifierRegistry.address);
-
-  // get the Transfer vkId
-  console.log('Reading vkIds from json file...');
-  const vkIds = await new Promise((resolve, reject) =>
-    jsonfile.readFile(config.VK_IDS, (err, data) => {
-      // doesn't natively support promises
-      if (err) reject(err);
-      else resolve(data);
-    }),
-  );
-  const { vkId } = vkIds.TransferCoin;
 
   const root = await fTokenShield.latestRoot();
   console.log(`Merkle Root: ${root}`);
@@ -499,7 +478,7 @@ account. All values are hex strings.
 @param {string} account - the that is paying for the transaction
 @param {string} payTo - the account that the paid-out ERC-20 should be sent to (defaults to 'account')
 */
-async function burn(C, skA, S_C, zC, zCIndex, account, _payTo) {
+async function burn(C, skA, S_C, zC, zCIndex, vkId, account, _payTo) {
   let payTo = _payTo;
   if (payTo === undefined) payTo = account; // have the option to pay out to another address
   // before we can burn, we need to deploy a verifying key to mintVerifier (reusing mint for this)
@@ -512,17 +491,6 @@ async function burn(C, skA, S_C, zC, zCIndex, account, _payTo) {
   console.log('FTokenShield contract address:', fTokenShield.address);
   console.log('Verifier contract address:', verifier.address);
   console.log('VerifierRegistry contract address:', verifierRegistry.address);
-
-  // get the Burn vkId
-  console.log('Reading vkIds from json file...');
-  const vkIds = await new Promise((resolve, reject) =>
-    jsonfile.readFile(config.VK_IDS, (err, data) => {
-      // doesn't natively support promises
-      if (err) reject(err);
-      else resolve(data);
-    }),
-  );
-  const { vkId } = vkIds.BurnCoin;
 
   const root = await fTokenShield.latestRoot(); // solidity getter for the public variable latestRoot
   console.log(`Merkle Root: ${root}`);

--- a/zkp/src/f-token-controller.js
+++ b/zkp/src/f-token-controller.js
@@ -203,14 +203,19 @@ knows S_A,pkA,n and n so could in fact calculate the token themselves.
 This is required for later transfers/joins so that Alice knows which 'chunks' of the Merkle Tree
 she needs to 'get' from the fTokenShield contract in order to calculate a path.
 */
-async function mint(A, pkA, S_A, vkId, account) {
+async function mint(A, pkA, S_A, vkId, blockchainOptions) {
+  const { account, fTokenShieldJson, fTokenShieldAddress } = blockchainOptions;
+
+  const fTokenShield = contract(fTokenShieldJson);
+  fTokenShield.setProvider(Web3.connect());
+  const fTokenShieldInstance = await fTokenShield.at(fTokenShieldAddress);
+
   console.group('\nIN MINT...');
 
   console.log('Finding the relevant Shield and Verifier contracts');
-  const fTokenShield = shield[account] ? shield[account] : await FTokenShield.deployed();
   const verifier = await Verifier.deployed();
   const verifierRegistry = await VerifierRegistry.deployed();
-  console.log('FTokenShield contract address:', fTokenShield.address);
+  console.log('FTokenShield contract address:', fTokenShieldInstance.address);
   console.log('Verifier contract address:', verifier.address);
   console.log('VerifierRegistry contract address:', verifierRegistry.address);
 
@@ -265,9 +270,9 @@ async function mint(A, pkA, S_A, vkId, account) {
 
   // next, we have to approve withdrawal of sufficient ERC-20 from the minter's
   // account to pay for the minted coin
-  console.log('Approving ERC-20 spend from: ', fTokenShield.address);
-  const fToken = await FToken.at(await fTokenShield.getFToken.call());
-  await fToken.approve(fTokenShield.address, parseInt(A, 16), {
+  console.log('Approving ERC-20 spend from: ', fTokenShieldInstance.address);
+  const fToken = await FToken.at(await fTokenShieldInstance.getFToken.call());
+  await fToken.approve(fTokenShieldInstance.address, parseInt(A, 16), {
     from: account,
     gas: 4000000,
     gasPrice: config.GASPRICE,
@@ -277,7 +282,7 @@ async function mint(A, pkA, S_A, vkId, account) {
 
   // with the pre-compute done, and the funds approved, we can mint the token,
   // which is now a reasonably light-weight calculation
-  const zAIndex = await zkp.mint(proof, inputs, vkId, A, zA, account, fTokenShield);
+  const zAIndex = await zkp.mint(proof, inputs, vkId, A, zA, account, fTokenShieldInstance);
 
   console.log('Mint output: [zA, zAIndex]:', zA, zAIndex.toString());
   console.log('MINT COMPLETE\n');
@@ -305,12 +310,18 @@ async function transfer(
   receiverPublicKey,
   senderSecretKey,
   vkId,
-  account,
+  blockchainOptions,
 ) {
   const { value: C, salt: S_C, commitment: zC, index: zCIndex } = inputCommitments[0];
   const { value: D, salt: S_D, commitment: zD, index: zDIndex } = inputCommitments[1];
   const { value: E, salt: S_E } = outputCommitments[0];
   const { value: F, salt: S_F } = outputCommitments[1];
+
+  const { account, fTokenShieldJson, fTokenShieldAddress } = blockchainOptions;
+
+  const fTokenShield = contract(fTokenShieldJson);
+  fTokenShield.setProvider(Web3.connect());
+  const fTokenShieldInstance = await fTokenShield.at(fTokenShieldAddress);
 
   console.group('\nIN TRANSFER...');
 
@@ -322,14 +333,13 @@ async function transfer(
   if (c > 0xffffffff || e > 0xffffffff) throw new Error('Coin values are too large');
 
   console.log('Finding the relevant Shield and Verifier contracts');
-  const fTokenShield = shield[account] ? shield[account] : await FTokenShield.deployed();
   const verifier = await Verifier.deployed();
   const verifierRegistry = await VerifierRegistry.deployed();
-  console.log('FTokenShield contract address:', fTokenShield.address);
+  console.log('FTokenShield contract address:', fTokenShieldInstance.address);
   console.log('Verifier contract address:', verifier.address);
   console.log('VerifierRegistry contract address:', verifierRegistry.address);
 
-  const root = await fTokenShield.latestRoot();
+  const root = await fTokenShieldInstance.latestRoot();
   console.log(`Merkle Root: ${root}`);
 
   // Calculate new arguments for the proof:
@@ -340,7 +350,7 @@ async function transfer(
   const zF = utils.concatenateThenHash(F, pkA, S_F);
 
   // we need the Merkle path from the token commitment to the root, expressed as Elements
-  const pathC = await cv.computePath(account, fTokenShield, zC, zCIndex);
+  const pathC = await cv.computePath(account, fTokenShieldInstance, zC, zCIndex);
   const pathCElements = {
     elements: pathC.path.map(
       element => new Element(element, 'field', config.MERKLE_HASHLENGTH * 8, 1),
@@ -349,7 +359,7 @@ async function transfer(
   };
   // console.log(`pathCElements.path:`, pathCElements.elements);
   // console.log(`pathCElements.positions:`, pathCElements.positions);
-  const pathD = await cv.computePath(account, fTokenShield, zD, zDIndex);
+  const pathD = await cv.computePath(account, fTokenShieldInstance, zD, zDIndex);
   const pathDElements = {
     elements: pathD.path.map(
       element => new Element(element, 'field', config.MERKLE_HASHLENGTH * 8, 1),
@@ -453,7 +463,7 @@ async function transfer(
     zE,
     zF,
     account,
-    fTokenShield,
+    fTokenShieldInstance,
   );
 
   console.log('TRANSFER COMPLETE\n');
@@ -478,28 +488,38 @@ account. All values are hex strings.
 @param {string} account - the that is paying for the transaction
 @param {string} payTo - the account that the paid-out ERC-20 should be sent to (defaults to 'account')
 */
-async function burn(C, skA, S_C, zC, zCIndex, vkId, account, _payTo) {
+async function burn(C, skA, S_C, zC, zCIndex, vkId, blockchainOptions) {
+  const {
+    account,
+    fTokenShieldJson,
+    fTokenShieldAddress,
+    tokenReceiver: _payTo,
+  } = blockchainOptions;
+
+  const fTokenShield = contract(fTokenShieldJson);
+  fTokenShield.setProvider(Web3.connect());
+  const fTokenShieldInstance = await fTokenShield.at(fTokenShieldAddress);
+
   let payTo = _payTo;
   if (payTo === undefined) payTo = account; // have the option to pay out to another address
   // before we can burn, we need to deploy a verifying key to mintVerifier (reusing mint for this)
   console.group('\nIN BURN...');
 
   console.log('Finding the relevant Shield and Verifier contracts');
-  const fTokenShield = shield[account] ? shield[account] : await FTokenShield.deployed();
   const verifier = await Verifier.deployed();
   const verifierRegistry = await VerifierRegistry.deployed();
-  console.log('FTokenShield contract address:', fTokenShield.address);
+  console.log('FTokenShield contract address:', fTokenShieldInstance.address);
   console.log('Verifier contract address:', verifier.address);
   console.log('VerifierRegistry contract address:', verifierRegistry.address);
 
-  const root = await fTokenShield.latestRoot(); // solidity getter for the public variable latestRoot
+  const root = await fTokenShieldInstance.latestRoot(); // solidity getter for the public variable latestRoot
   console.log(`Merkle Root: ${root}`);
 
   // Calculate new arguments for the proof:
   const Nc = utils.concatenateThenHash(S_C, skA);
 
   // We need the Merkle path from the commitment to the root, expressed as Elements
-  const path = await cv.computePath(account, fTokenShield, zC, zCIndex);
+  const path = await cv.computePath(account, fTokenShieldInstance, zC, zCIndex);
   const pathElements = {
     elements: path.path.map(
       element => new Element(element, 'field', config.MERKLE_HASHLENGTH * 8, 1),
@@ -569,7 +589,7 @@ async function burn(C, skA, S_C, zC, zCIndex, vkId, account, _payTo) {
 
   // with the pre-compute done we can burn the token, which is now a reasonably
   // light-weight calculation
-  await zkp.burn(proof, inputs, vkId, root, Nc, C, payTo, account, fTokenShield);
+  await zkp.burn(proof, inputs, vkId, root, Nc, C, payTo, account, fTokenShieldInstance);
 
   console.log('BURN COMPLETE\n');
   console.groupEnd();

--- a/zkp/src/nf-token-controller.js
+++ b/zkp/src/nf-token-controller.js
@@ -224,7 +224,7 @@ This is a convenience because the sender (Alice)
 knows S_A,pk_A,n and n so could in fact calculate the token themselves.
 @returns {Integer} z_A_index - the index of the token within the Merkle Tree.  This is required for later transfers/joins so that Alice knows which 'chunks' of the Merkle Tree she needs to 'get' from the NFTokenShield contract in order to calculate a path.
 */
-async function mint(A, pk_A, S_A, account) {
+async function mint(A, pk_A, S_A, vkId, account) {
   console.group('\nIN MINT...');
 
   console.info('Finding the relevant Shield and Verifier contracts...');
@@ -234,17 +234,6 @@ async function mint(A, pk_A, S_A, account) {
   console.log('NFTokenShield contract address:', nfTokenShield.address);
   console.log('Verifier contract address:', verifier.address);
   console.log('Verifier_Registry contract address:', verifier_registry.address);
-
-  // get the vkId for a Mint
-  console.log('Reading vkIds from json file...');
-  const vkIds = await new Promise((resolve, reject) =>
-    jsonfile.readFile(config.VK_IDS, (err, data) => {
-      // doesn't natively support promises
-      if (err) reject(err);
-      else resolve(data);
-    }),
-  );
-  const { vkId } = vkIds.MintToken;
 
   // Calculate new arguments for the proof:
   const z_A = utils.concatenateThenHash(utils.strip0x(A).slice(-32 * 2), pk_A, S_A);
@@ -326,7 +315,7 @@ This function actually transfers a token, assuming that we have a proof.
 @returns {Integer} z_B_index - the index of the token within the Merkle Tree.  This is required for later transfers/joins so that Alice knows which 'chunks' of the Merkle Tree she needs to 'get' from the NFTokenShield contract in order to calculate a path.
 @returns {object} txObj - a promise of a blockchain transaction
 */
-async function transfer(A, pk_B, S_A, S_B, sk_A, z_A, z_A_index, account) {
+async function transfer(A, pk_B, S_A, S_B, sk_A, z_A, z_A_index, vkId, account) {
   console.group('\nIN TRANSFER...');
 
   console.log('Finding the relevant Shield and Verifier contracts');
@@ -336,17 +325,6 @@ async function transfer(A, pk_B, S_A, S_B, sk_A, z_A, z_A_index, account) {
   console.log('NFTokenShield contract address:', nfTokenShield.address);
   console.log('Verifier contract address:', verifier.address);
   console.log('Verifier_Registry contract address:', verifier_registry.address);
-
-  // get the Transfer vkId
-  console.log('Reading vkIds from json file...');
-  const vkIds = await new Promise((resolve, reject) =>
-    jsonfile.readFile(config.VK_IDS, (err, data) => {
-      // doesn't natively support promises
-      if (err) reject(err);
-      else resolve(data);
-    }),
-  );
-  const { vkId } = vkIds.TransferToken;
 
   // Get token data from the Shield contract:
   const root = await nfTokenShield.latestRoot(); // solidity getter for the public variable latestRoot

--- a/zkp/src/nf-token-controller.js
+++ b/zkp/src/nf-token-controller.js
@@ -224,14 +224,19 @@ This is a convenience because the sender (Alice)
 knows S_A,pk_A,n and n so could in fact calculate the token themselves.
 @returns {Integer} z_A_index - the index of the token within the Merkle Tree.  This is required for later transfers/joins so that Alice knows which 'chunks' of the Merkle Tree she needs to 'get' from the NFTokenShield contract in order to calculate a path.
 */
-async function mint(A, pk_A, S_A, vkId, account) {
+async function mint(A, pk_A, S_A, vkId, blockchainOptions) {
+  const { account, nfTokenShieldJson, nfTokenShieldAddress } = blockchainOptions;
+
+  const nfTokenShield = contract(nfTokenShieldJson);
+  nfTokenShield.setProvider(Web3.connect());
+  const nfTokenShieldInstance = await nfTokenShield.at(nfTokenShieldAddress);
+
   console.group('\nIN MINT...');
 
   console.info('Finding the relevant Shield and Verifier contracts...');
-  const nfTokenShield = shield[account] ? shield[account] : await NFTokenShield.deployed();
   const verifier = await Verifier.deployed();
   const verifier_registry = await Verifier_Registry.deployed();
-  console.log('NFTokenShield contract address:', nfTokenShield.address);
+  console.log('NFTokenShield contract address:', nfTokenShieldInstance.address);
   console.log('Verifier contract address:', verifier.address);
   console.log('Verifier_Registry contract address:', verifier_registry.address);
 
@@ -290,9 +295,10 @@ async function mint(A, pk_A, S_A, vkId, account) {
   console.log('Check that a registry has actually been registered:', registry);
 
   // make token shield contract an approver to transfer this token on behalf of the owner (to comply with the standard as msg.sender has to be owner or approver)
-  await addApproverNFToken(nfTokenShield.address, A, account);
+  await addApproverNFToken(nfTokenShieldInstance.address, A, account);
+
   // with the pre-compute done we can mint the token, which is now a reasonably light-weight calculation
-  const z_A_index = await zkp.mint(proof, inputs, vkId, A, z_A, account, nfTokenShield);
+  const z_A_index = await zkp.mint(proof, inputs, vkId, A, z_A, account, nfTokenShieldInstance);
 
   console.log('Mint output: [z_A, z_A_index]:', z_A, z_A_index.toString());
   console.log('MINT COMPLETE\n');
@@ -315,19 +321,22 @@ This function actually transfers a token, assuming that we have a proof.
 @returns {Integer} z_B_index - the index of the token within the Merkle Tree.  This is required for later transfers/joins so that Alice knows which 'chunks' of the Merkle Tree she needs to 'get' from the NFTokenShield contract in order to calculate a path.
 @returns {object} txObj - a promise of a blockchain transaction
 */
-async function transfer(A, pk_B, S_A, S_B, sk_A, z_A, z_A_index, vkId, account) {
-  console.group('\nIN TRANSFER...');
+async function transfer(A, pk_B, S_A, S_B, sk_A, z_A, z_A_index, vkId, blockchainOptions) {
+  const { account, nfTokenShieldJson, nfTokenShieldAddress } = blockchainOptions;
+
+  const nfTokenShield = contract(nfTokenShieldJson);
+  nfTokenShield.setProvider(Web3.connect());
+  const nfTokenShieldInstance = await nfTokenShield.at(nfTokenShieldAddress);
 
   console.log('Finding the relevant Shield and Verifier contracts');
-  const nfTokenShield = shield[account] ? shield[account] : await NFTokenShield.deployed();
-  const verifier = await Verifier.at(await nfTokenShield.getVerifier.call());
+  const verifier = await Verifier.at(await nfTokenShieldInstance.getVerifier.call());
   const verifier_registry = await Verifier_Registry.at(await verifier.getRegistry.call());
-  console.log('NFTokenShield contract address:', nfTokenShield.address);
+  console.log('NFTokenShield contract address:', nfTokenShieldInstance.address);
   console.log('Verifier contract address:', verifier.address);
   console.log('Verifier_Registry contract address:', verifier_registry.address);
 
   // Get token data from the Shield contract:
-  const root = await nfTokenShield.latestRoot(); // solidity getter for the public variable latestRoot
+  const root = await nfTokenShieldInstance.latestRoot(); // solidity getter for the public variable latestRoot
   console.log(`Merkle Root: ${root}`);
 
   // Calculate new arguments for the proof:
@@ -339,7 +348,7 @@ async function transfer(A, pk_B, S_A, S_B, sk_A, z_A, z_A_index, vkId, account) 
   );
 
   // we need the Merkle path from the token commitment to the root, expressed as Elements
-  const path = await cv.computePath(account, nfTokenShield, z_A, z_A_index).then(result => {
+  const path = await cv.computePath(account, nfTokenShieldInstance, z_A, z_A_index).then(result => {
     return {
       elements: result.path.map(
         element => new Element(element, 'field', config.MERKLE_HASHLENGTH * 8, 1),
@@ -420,7 +429,7 @@ async function transfer(A, pk_B, S_A, S_B, sk_A, z_A, z_A_index, vkId, account) 
     n,
     z_B,
     account,
-    nfTokenShield,
+    nfTokenShieldInstance,
   );
 
   console.log('TRANSFER COMPLETE\n');
@@ -437,7 +446,18 @@ async function transfer(A, pk_B, S_A, S_B, sk_A, z_A, z_A_index, vkId, account) 
 this function burns a token, i.e. it recovers real NF Token (ERC 721) into the
 account specified by payTo
 */
-async function burn(A, Sk_A, S_A, z_A, z_A_index, account, payTo) {
+async function burn(A, Sk_A, S_A, z_A, z_A_index, vkId, blockchainOptions) {
+  const {
+    account,
+    nfTokenShieldJson,
+    nfTokenShieldAddress,
+    tokenReceiver: payTo,
+  } = blockchainOptions;
+
+  const nfTokenShield = contract(nfTokenShieldJson);
+  nfTokenShield.setProvider(Web3.connect());
+  const nfTokenShieldInstance = await nfTokenShield.at(nfTokenShieldAddress);
+
   const payToOrDefault = payTo || account; // have the option to pay out to another address
   console.group('\nIN BURN...');
   console.log('A', A);
@@ -449,32 +469,20 @@ async function burn(A, Sk_A, S_A, z_A, z_A_index, account, payTo) {
   console.log('payTo', payToOrDefault);
 
   console.log('Finding the relevant Shield and Verifier contracts');
-  const nfTokenShield = shield[account] ? shield[account] : await NFTokenShield.deployed();
   const verifier = await Verifier.deployed();
   const verifier_registry = await Verifier_Registry.deployed();
-  console.log('NFTokenShield contract address:', nfTokenShield.address);
+  console.log('NFTokenShield contract address:', nfTokenShieldInstance.address);
   console.log('Verifier contract address:', verifier.address);
   console.log('Verifier_Registry contract address:', verifier_registry.address);
 
-  // get the Burn vkId
-  console.log('Reading vkIds from json file...');
-  const vkIds = await new Promise((resolve, reject) =>
-    jsonfile.readFile(config.VK_IDS, (err, data) => {
-      // doesn't natively support promises
-      if (err) reject(err);
-      else resolve(data);
-    }),
-  );
-  const { vkId } = vkIds.BurnToken;
-
-  const root = await nfTokenShield.latestRoot(); // solidity getter for the public variable latestRoot
+  const root = await nfTokenShieldInstance.latestRoot(); // solidity getter for the public variable latestRoot
   console.log(`Merkle Root: ${root}`);
 
   // Calculate new arguments for the proof:
   const Na = utils.concatenateThenHash(S_A, Sk_A);
 
   // we need the Merkle path from the token commitment to the root, expressed as Elements
-  const path = await cv.computePath(account, nfTokenShield, z_A, z_A_index).then(result => {
+  const path = await cv.computePath(account, nfTokenShieldInstance, z_A, z_A_index).then(result => {
     return {
       elements: result.path.map(
         element => new Element(element, 'field', config.MERKLE_HASHLENGTH * 8, 1),
@@ -546,7 +554,7 @@ async function burn(A, Sk_A, S_A, z_A, z_A_index, account, payTo) {
 
   // with the pre-compute done we can burn the token, which is now a reasonably
   // light-weight calculation
-  await zkp.burn(proof, inputs, vkId, root, Na, A, payTo, account, nfTokenShield);
+  await zkp.burn(proof, inputs, vkId, root, Na, A, payTo, account, nfTokenShieldInstance);
 
   console.log('BURN COMPLETE\n');
   console.groupEnd();

--- a/zkp/src/routes/ft-commitment.js
+++ b/zkp/src/routes/ft-commitment.js
@@ -3,6 +3,7 @@
 import { Router } from 'express';
 import utils from 'zkp-utils';
 import fTokenController from '../f-token-controller';
+import { getVkId } from '../contractUtils';
 
 const router = Router();
 
@@ -10,9 +11,16 @@ async function mint(req, res, next) {
   const { address } = req.headers;
   const { A: amount, pk_A: ownerPublicKey } = req.body;
   const salt = await utils.rndHex(32);
+  const vkId = await getVkId('MintCoin');
 
   try {
-    const [coin, coin_index] = await fTokenController.mint(amount, ownerPublicKey, salt, address);
+    const [coin, coin_index] = await fTokenController.mint(
+      amount,
+      ownerPublicKey,
+      salt,
+      vkId,
+      address,
+    );
     res.data = {
       coin,
       coin_index,
@@ -40,6 +48,7 @@ async function transfer(req, res, next) {
     z_D,
     z_D_index,
   } = req.body;
+  const vkId = await getVkId('TransferCoin');
 
   const inputCommitments = [
     {
@@ -73,6 +82,7 @@ async function transfer(req, res, next) {
       outputCommitments,
       receiverPublicKey,
       senderSecretKey,
+      vkId,
       address,
     );
     res.data = {
@@ -100,6 +110,7 @@ async function burn(req, res, next) {
     payTo: tokenReceiver,
   } = req.body;
   const { address } = req.headers;
+  const vkId = await getVkId('BurnCoin');
 
   try {
     await fTokenController.burn(
@@ -108,6 +119,7 @@ async function burn(req, res, next) {
       salt,
       commitment,
       commitmentIndex,
+      vkId,
       address,
       tokenReceiver,
     );

--- a/zkp/src/routes/nft-commitment.js
+++ b/zkp/src/routes/nft-commitment.js
@@ -3,6 +3,7 @@
 import { Router } from 'express';
 import utils from 'zkp-utils';
 import nfController from '../nf-token-controller';
+import { getVkId } from '../contractUtils';
 
 const router = Router();
 
@@ -10,9 +11,10 @@ async function mint(req, res, next) {
   const { address } = req.headers;
   const { A: tokenId, pk_A: ownerPublicKey } = req.body;
   const salt = await utils.rndHex(32);
+  const vkId = await getVkId('MintToken');
 
   try {
-    const [z_A, z_A_index] = await nfController.mint(tokenId, ownerPublicKey, salt, address);
+    const [z_A, z_A_index] = await nfController.mint(tokenId, ownerPublicKey, salt, vkId, address);
 
     res.data = {
       z_A,
@@ -36,6 +38,8 @@ async function transfer(req, res, next) {
   } = req.body;
   const newCommitmentSalt = await utils.rndHex(32);
   const { address } = req.headers;
+  const vkId = await getVkId('TransferToken');
+
   try {
     const { z_B, z_B_index, txObj } = await nfController.transfer(
       tokenId,
@@ -45,6 +49,7 @@ async function transfer(req, res, next) {
       senderSecretKey,
       commitment,
       commitmentIndex,
+      vkId,
       address,
     );
     res.data = {
@@ -69,6 +74,8 @@ async function burn(req, res, next) {
     payTo: tokenReceiver,
   } = req.body;
   const { address } = req.headers;
+  const vkId = await getVkId('BurnToken');
+
   try {
     await nfController.burn(
       tokenId,
@@ -76,6 +83,7 @@ async function burn(req, res, next) {
       salt,
       commitment,
       commitmentIndex,
+      vkId,
       address,
       tokenReceiver, // payed to same user.
     );


### PR DESCRIPTION
# Description

<!--- Describe your changes in detail -->

Pulls getters for vkId and contract details out of the ZKP functions
 
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The ZKP functions as-is make a lot of assumptions as to where certain files are stored. For example, they assume that the vk IDs are stored in a JSON file in a certain location in the file system. Other applications may not have these same assumptions, for example, VKIDs may be stored in MongoDB. 

Additionally, these functions assume that the rest of the application is using truffle-contract, but other applications may be using ethers, or web3. By supplying the JSON and the address, and reinstantiating the contract object within the function, these functions are now agnostic of what the rest of the application is using.