### PR TITLE
take out line "has recipe in makefile"

### DIFF
--- a/zkp/README.md
+++ b/zkp/README.md
@@ -12,7 +12,7 @@ You will need key pairs to run the full application. And the `setupAll` script d
 
 ⚠️ This task will run approximately one to three hours depending on your machine.
 
-📖 ​This task has a recipe in [the Nightfall makefile](../Makefile), execute it using `make zkp-generate-keys` from the top-level folder. Or you can directly run:
+📖 You can also directly run:
 
 ```sh
 docker-compose run --rm zkp --env NODE_ENV=setup npx babel-node code/index.js


### PR DESCRIPTION
# Description

In the README, there is a line stating that there is a key generation recipe in the Makefile. That recipe no longer exists. 


## Motivation and Context

This will prevent future users from being confused.

## How Has This Been Tested

Verified that there is indeed no way to generate keys from Makefile. Checked the Markdown to make sure nothing else was deleted. 

## Types of changes
comment fix
