### PR TITLE
Refactor setupAll, pull in zokrates.js

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,7 +2,6 @@ node_modules
 mochawesome-report
 zkp/src/vkIds.json
 zkp/migrations
-zkp/code
 account-utils
 zkp-utils/node_modules
 offchain/migrations

--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Generate the keys and constraint files for Zero Knowledge Proofs
         run: |
           chmod -R 777 zkp/code/
-          ./nightfall-generate-trusted-setup
+          npm run setupAll
       - name: Remove ZoKrates Containers
         run: |
           docker stop $(docker ps -a -q)
@@ -76,7 +76,7 @@ jobs:
       - name: Generate the keys and constraint files for Zero Knowledge Proofs
         run: |
           chmod -R 777 zkp/code/
-          ./nightfall-generate-trusted-setup
+          npm run setupAll
       - name: Remove ZoKrates Containers
         run: |
           docker stop $(docker ps -a -q)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     restart: on-failure
     depends_on:
       - accounts
-      - offchain      
+      - offchain
       - zkp
       - database
     volumes:
@@ -31,7 +31,7 @@ services:
       - ./api-gateway/config:/app/config
       - ./api-gateway/.babelrc:/app/.babelrc
     ports:
-      - "8001:80"
+      - '8001:80'
     environment:
       ACCOUNTS_HOST: http://accounts
       ACCOUNTS_PORT: 80
@@ -93,13 +93,13 @@ services:
       - ./ui/angular.json:/app/angular.json
       - ./ui/tsconfig.json:/app/tsconfig.json
     ports:
-      - "8000:80"
+      - '8000:80'
 
   ganache:
     image: trufflesuite/ganache-cli:latest
     command: ganache-cli --accounts=10 --defaultBalanceEther=1000
     ports:
-      - "8545:8545"
+      - '8545:8545'
 
   database:
     build:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Nightfall",
+  "name": "nightfall",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -1185,6 +1185,11 @@
       "requires": {
         "find-up": "^2.1.0"
       }
+    },
+    "@eyblockchain/zokrates.js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@eyblockchain/zokrates.js/-/zokrates.js-1.2.0.tgz",
+      "integrity": "sha512-R/bEmqJbYF9EcXatn1xT499M8BfVIlK/DkPyd7RMNRWiQ5D1/MHSHRWomHsbvaQVaAnLZap+zc6lc5J111i7Ng=="
     },
     "@marionebl/sander": {
       "version": "0.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1186,11 +1186,6 @@
         "find-up": "^2.1.0"
       }
     },
-    "@eyblockchain/zokrates.js": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@eyblockchain/zokrates.js/-/zokrates.js-1.2.0.tgz",
-      "integrity": "sha512-R/bEmqJbYF9EcXatn1xT499M8BfVIlK/DkPyd7RMNRWiQ5D1/MHSHRWomHsbvaQVaAnLZap+zc6lc5J111i7Ng=="
-    },
     "@marionebl/sander": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/@marionebl/sander/-/sander-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "NODE_CONFIG_DIR=./integration-test/config mocha --require @babel/register -b ./integration-test/ --reporter mochawesome --timeout 1000000",
+    "setup": "docker-compose run zkp npm run setup --",
     "setupAll": "docker-compose run zkp npm run setup-all",
     "fix": "npm run format && npm run lint -- --fix",
     "format": "prettier --write \"**/*.{json,css,scss,md,html}\"",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "homepage": "https://github.com/EYBlockchain/nightfall#readme",
   "dependencies": {
-    "@eyblockchain/zokrates.js": "^1.2.0",
     "lodash": "^4.17.15",
     "typescript": "^2.9.2"
   },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "NODE_CONFIG_DIR=./integration-test/config mocha --require @babel/register -b ./integration-test/ --reporter mochawesome --timeout 1000000",
+    "setupAll": "docker-compose run zkp npm run setup-all",
     "fix": "npm run format && npm run lint -- --fix",
     "format": "prettier --write \"**/*.{json,css,scss,md,html}\"",
     "lint": "eslint .",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "homepage": "https://github.com/EYBlockchain/nightfall#readme",
   "dependencies": {
+    "@eyblockchain/zokrates.js": "^1.2.0",
     "lodash": "^4.17.15",
     "typescript": "^2.9.2"
   },

--- a/zkp/Dockerfile
+++ b/zkp/Dockerfile
@@ -1,7 +1,11 @@
+# Pull in a Zokrates container so that we can pull its contents into the below container.
+FROM zokrates/zokrates:0.4.11 as builder
+
 FROM node:11.15
-
 WORKDIR /app
-
+# Copy over Zokrates files into this container
+COPY --from=builder /home/zokrates/zokrates /app/zokrates
+COPY --from=builder /home/zokrates/.zokrates* /app/stdlib
 COPY ./package.json ./package-lock.json ./
 RUN npm ci
 

--- a/zkp/README.md
+++ b/zkp/README.md
@@ -1,21 +1,25 @@
 # Nightfall Zero-Knowledge Proof Service
 
-*This module is part of Nightfall. Most users will only be interested in using the application as a whole, we direct those readers to [the main README](../../README.md). This file provides additional information on how this module works so you can learn about, tinker and improve it.*
+_This module is part of Nightfall. Most users will only be interested in using the application as a
+whole, we direct those readers to [the main README](../../README.md). This file provides additional
+information on how this module works so you can learn about, tinker and improve it._
 
 ## Tasks you can perform
 
 ### Run zkp service unit tests
 
-You will need to have completed the trusted setup. This is done simply by running (from the Nightfall root):
+You will need to have completed the trusted setup. This is done simply by running (from the
+Nightfall root):
 
 ```sh
 ./nightfall-generate-trusted-setup
 ```
-If you have previously run the Nightfall application, you will already have completed this step and there is no need to repeat it (it takes about and hour so it's worth avoiding where possible!).
+
+If you have previously run the Nightfall application, you will already have completed this step and
+there is no need to repeat it (it takes about and hour so it's worth avoiding where possible!).
 
 _Alternatively_, if you change one of the proofs in the Nightfall suite, then you can perform the
-trusted setup for just that proof, which is a lot faster. You need to change to the zkp sub directory
-to do that:
+trusted setup for just that proof, which is a lot faster by running
 
 ```sh
 cd zkp
@@ -23,7 +27,8 @@ npm run setup -- -i gm17/<dir containing your proof>
 cd ..
 ```
 
-Also, before running these tests, don't forget to make sure you have a current version of the zkp container.  If in doubt, run:
+Also, before running these tests, don't forget to make sure you have a current version of the zkp
+container. If in doubt, run:
 
 ```sh
 docker-compose build zkp
@@ -54,10 +59,11 @@ The relevant files for these tests can be found under `zkp/__tests__`.
 
 Note that the zkp service tests take a while to run (approx. 1 hour)
 
-
 ### Development
 
-Running the zkp module as part of the fully application is handled by Docker Compose. But you will be running this directly on your machine. Prerequesites for development of Nightfall are documented in [the main project README](../README.md). Satisfy those first before proceeding.
+Running the zkp module as part of the fully application is handled by Docker Compose. But you will
+be running this directly on your machine. Prerequesites for development of Nightfall are documented
+in [the main project README](../README.md). Satisfy those first before proceeding.
 
 Build and run service (on port 80)
 
@@ -92,6 +98,9 @@ rm -rf node_modules
 
 ## Further reading
 
-* [README-tools-trusted-setup.md](code/README-tools-trusted-setup.md) explains the steps that npm will run in the "setup" and "setupAll" tasks.
-* [README-manual-trusted-setup.md](code/README-manual-trusted-setup.md) is a deeper walkthrough of the "generating key pairs" task above.
-* [README-tools-code-preprop.md](code/README-tools-code-preprop.md) explains "pcode", an abbreviated language Nightfall uses that transpiles down to the ZoKrates "code" language.
+- [README-tools-trusted-setup.md](code/README-tools-trusted-setup.md) explains the steps that npm
+  will run in the "setup" and "setupAll" tasks.
+- [README-manual-trusted-setup.md](code/README-manual-trusted-setup.md) is a deeper walkthrough of
+  the "generating key pairs" task above.
+- [README-tools-code-preprop.md](code/README-tools-code-preprop.md) explains "pcode", an abbreviated
+  language Nightfall uses that transpiles down to the ZoKrates "code" language.

--- a/zkp/README.md
+++ b/zkp/README.md
@@ -22,9 +22,7 @@ _Alternatively_, if you change one of the proofs in the Nightfall suite, then yo
 trusted setup for just that proof, which is a lot faster by running
 
 ```sh
-cd zkp
 npm run setup -- -i gm17/<dir containing your proof>
-cd ..
 ```
 
 Also, before running these tests, don't forget to make sure you have a current version of the zkp

--- a/zkp/__tests__/f-token-controller.test.js
+++ b/zkp/__tests__/f-token-controller.test.js
@@ -1,8 +1,8 @@
 /* eslint-disable import/no-unresolved */
 
-import utils from 'zkp-utils';
 import bc from '../src/web3';
 
+import utils from '../src/zkpUtils';
 import controller from '../src/f-token-controller';
 import { getVkId, getContract } from '../src/contractUtils';
 

--- a/zkp/__tests__/nf-token-controller.test.js
+++ b/zkp/__tests__/nf-token-controller.test.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-unresolved */
 
-import utils from 'zkp-utils';
+import utils from '../src/zkpUtils';
 import bc from '../src/web3';
 import controller from '../src/nf-token-controller';
 import { getVkId, getContract } from '../src/contractUtils';

--- a/zkp/__tests__/utils.test.js
+++ b/zkp/__tests__/utils.test.js
@@ -1,4 +1,4 @@
-import utils from 'zkp-utils';
+import utils from '../src/zkpUtils';
 
 const dec = '17408914224622445472';
 const hex = '0xf198e3403bdda3a0';

--- a/zkp/code/README-trusted-setup.md
+++ b/zkp/code/README-trusted-setup.md
@@ -21,11 +21,11 @@ can be gigabytes in size.
 
 ### ZoKrates
 
-Note: `npm run setupAll` pulls an image of zokrates from dockerhub (see src/config.js for the current
-zokrates image being used). Since ZoKrates is still a fast-changing project (with many breaking
-changes being pushed to its repo), it is likely that this opensource Nightfall repo will lag behind
-the latest zokrates images and DSL syntax. This tool will need to updated alongside any new versions
-of zokrates.
+Note: `npm run setupAll` pulls an image of zokrates from dockerhub (see src/config.js for the
+current zokrates image being used). Since ZoKrates is still a fast-changing project (with many
+breaking changes being pushed to its repo), it is likely that this opensource Nightfall repo will
+lag behind the latest zokrates images and DSL syntax. This tool will need to updated alongside any
+new versions of zokrates.
 
 ## Requirements
 
@@ -54,26 +54,18 @@ index.js is written to interpret .code syntax.
 
 ## Quick start
 
-Always run from within nightfall/zkp/:
+From the root directory, you can run the trusted setup on all folders under `zkp/code/gm17` by
+running:
 
-```sh
-npm install
-cd path/to/nightfall/zkp/
-```
+`npm run setupAll`
 
-Then run the tool:
+### Running Trusted Setup On One Code File
 
-`npm run setup -- -i gm17/parent-dir-of-pcode/`
+Alternatively, you can run the trusted setup on a specific code file by running:
 
-## Arguments: `-i` `-a` `-s`
+`npm run setup -- -i gm17/<Code File Directory≥/`
 
-### `-i`
-
-Alternatively you can process _all_ of the folders under `/gm17` in one go by using:
-
-`npm run setup-all`
-
-Note that this will take about 1hr to complete.
+For example: `npm run setup -- -i gm17/ft-mint`
 
 Recommended initial filing structure:
 
@@ -147,42 +139,7 @@ zkp
       |
 ```
 
-If `-i` is not specified, the code will loop through every single folder within `gm17` and perform a
-trusted setup but will ask you before doing each one (unlike `npm run setupAll`, which won't ask).
-This is done sequentially, because each setup requires a significant amount of computing resources.
-
-### `-a`
-
-`-a "<argument list>"` OPTIONAL
-
-Provide arguments and this tool will compute-witness using those arguments.
-
-e.g.  
-`node src/index.js -i gm17/parent-dir-of-pcode/ -a "1 0 0 1 1 1 1 0 0"` <--- **notice
-the "quotes"!!** The above `-a` will run, within the zokrates container, the following:
-`./zokrates compute-witness -a 1 0 0 1 1 1 1 0 0`
-
-**Important Note:** _Multiple arguments must be specified "within quotes" with spaces in between._
-
-#### console output of `-a` - useful for testing .code file variables
-
-If -a is specified, 'compute-witness' is run.
-
-E.g. the example output below is the 256bit output of the sha256() hash, as computed within a .code
-file.
-
-```sh
-Output from compute-witness:
-
- bin:  1100110011100001100001110100010001011010111101111001001010011011000100000110010101001010110011101111101001001110010100101111001110011011101111001000101000100001000100111011000010001110000010011010111010001011010111010010110000100000000110110001111111001111
- dec:  92670295279174621537561163145043938646856290957242631959181838212798520958927
- hex:  0xcce187445af7929b10654acefa4e52f39bbc8a2113b08e09ae8b5d2c201b1fcf
-```
-
-This tool tries to interpret the output as either binary or decimal, and then does a conversion
-based on this interpretation, to output equivalent bin, dec, and hex values.
-
-### `-s`
+### Suppress Console Logs
 
 `-s` OPTIONAL `-s` is for **suppression** of lengthy console outputs from the zokrates container. If
 `-s` is included, then lengthy console outputs will be suppressed. If `-s` is not included, all of

--- a/zkp/code/config.js
+++ b/zkp/code/config.js
@@ -54,7 +54,7 @@ const props = {
     ZOKRATES_PRIME: '21888242871839275222246405745257275088548364400416034343698204186575808495617', // decimal representation of the prime p of GaloisField(p)
     // NOTE: 2^253 < ZOKRATES_PRIME < 2^254 - so we must use 253bit numbers to be safe (and lazy) - let's use 248bit numbers (because hex numbers ought to be an even length, and 8 divides 248 (248 is 31 bytes is 62 hex numbers))
     ZOKRATES_PACKING_SIZE: '128', // ZOKRATES_PRIME is approx 253-254bits (just shy of 256), so we pack field elements into blocks of 128 bits.
-    MERKLE_DEPTH: 33, //the depth of the coin Merkle tree
+    MERKLE_DEPTH: 33, // the depth of the coin Merkle tree
     MERKLE_CHUNK_SIZE: 512, // the number of tokens contained in a chunk of the merkle tree.
 
     ZOKRATES_BACKEND: 'gm17',

--- a/zkp/code/index.js
+++ b/zkp/code/index.js
@@ -115,6 +115,8 @@ async function filingChecks(codeDirectory) {
 async function generateZokratesFiles(directoryPath) {
   const files = await readdirAsync(directoryPath);
 
+  console.group(`Setup for directory ${directoryPath}`);
+
   const directoryWithSlash = directoryPath.endsWith('/') ? directoryPath : `${directoryPath}/`;
 
   let codeFile;
@@ -129,29 +131,36 @@ async function generateZokratesFiles(directoryPath) {
   console.log('Compiling at', `${directoryWithSlash}${codeFile}`);
 
   // Generate out.code and out in the same directory.
-  await compile(`${directoryWithSlash}${codeFile}`, directoryWithSlash);
+  const compileOutput = await compile(`${directoryWithSlash}${codeFile}`, directoryWithSlash);
+  console.log('Compile output:', compileOutput);
   console.log('Finished compiling at', directoryPath);
 
+  console.log('Running setup on', directoryPath);
   // Generate verification.key and proving.key
-  await setup(
+  const setupOutput = await setup(
     `${directoryWithSlash}out`,
     directoryWithSlash,
     'gm17',
     'verification.key',
     'proving.key',
   );
+  console.log('Setup output:', setupOutput);
   console.log('Finished setup at', directoryPath);
 
-  await exportVerifier(
+  console.log('Running export-verifier at', directoryPath);
+  const exportVerifierOutput = await exportVerifier(
     `${directoryWithSlash}/verification.key`,
     directoryWithSlash,
     'verifier.sol',
     'gm17',
   );
+  console.log('Export-verifier output:', exportVerifierOutput);
   console.log('Finished export-verifier at', directoryPath);
 
+  console.log(`Extracting key from ${directoryWithSlash}verifier.sol`);
   const vkJson = await keyExtractor(`${directoryWithSlash}verifier.sol`, true);
 
+  console.log(`Writing ${directoryWithSlash}${codeFile.split('.')[0]}-vk.json`);
   // Create a JSON with the file name but without .code
   fs.writeFileSync(`${directoryWithSlash}${codeFile.split('.')[0]}-vk.json`, vkJson, err => {
     if (err) {

--- a/zkp/code/index.js
+++ b/zkp/code/index.js
@@ -131,7 +131,14 @@ async function generateZokratesFiles(directoryPath) {
   console.log('Compiling at', `${directoryWithSlash}${codeFile}`);
 
   // Generate out.code and out in the same directory.
-  const compileOutput = await compile(`${directoryWithSlash}${codeFile}`, directoryWithSlash);
+  const compileOutput = await compile(
+    `${directoryWithSlash}${codeFile}`,
+    directoryWithSlash,
+    'out',
+    {
+      verbose: true,
+    },
+  );
   console.log('Compile output:', compileOutput);
   console.log('Finished compiling at', directoryPath);
 
@@ -143,6 +150,7 @@ async function generateZokratesFiles(directoryPath) {
     'gm17',
     'verification.key',
     'proving.key',
+    { verbose: true },
   );
   console.log('Setup output:', setupOutput);
   console.log('Finished setup at', directoryPath);
@@ -153,6 +161,7 @@ async function generateZokratesFiles(directoryPath) {
     directoryWithSlash,
     'verifier.sol',
     'gm17',
+    { verbose: true },
   );
   console.log('Export-verifier output:', exportVerifierOutput);
   console.log('Finished export-verifier at', directoryPath);
@@ -168,6 +177,7 @@ async function generateZokratesFiles(directoryPath) {
     }
   });
   console.log(directoryPath, 'is done setting up.');
+  console.groupEnd();
 }
 
 /**

--- a/zkp/code/index.js
+++ b/zkp/code/index.js
@@ -5,17 +5,16 @@
 */
 
 import { argv } from 'yargs';
+import util from 'util';
 import os from 'os';
 import fs from 'fs';
 import path from 'path';
 import inquirer from 'inquirer';
-import config from 'config';
+// eslint-disable-next-line import/extensions
+import { compile, setup, exportVerifier } from '@eyblockchain/zokrates.js';
+import keyExtractor from './keyExtractor';
 
-import keyExtractor from './key-extractor';
-
-import zokrates from '../src/zokrates';
-
-const utils = require('../../zkp-utils/index.js'); // eslint-disable-line import/no-commonjs
+const readdirAsync = util.promisify(fs.readdir);
 
 const isDirectory = source => fs.lstatSync(source).isDirectory();
 const getDirectories = source =>
@@ -24,54 +23,12 @@ const getDirectories = source =>
     .map(name => path.join(source, name))
     .filter(isDirectory);
 
-let container;
-
-// SORT THROUGH ARGS:
-
-// arguments to the command line:
-// i - filename
-const { i } = argv; // file name - pass the my-code.code file as the '-i' parameter
-
-// a - arguments for compute-witness
-const a0 = argv.a; // arguments for compute-witness (within quotes "")
-let a1 = [];
-if (!(a0 === undefined || a0 === '')) {
-  a1 = a0.split(' ');
-} else {
-  a1 = null;
-}
-
-// s - suppress console streams
-const { s } = argv; // suppress - stream off if -s is specified
-
-// d - delete finished containers (WARNING: might delete containers for which the setup failed, so you wouldn't be able to go in and investigate the problem)
-const { d } = argv;
-
-/** create a promise that resolves to the output of a stream when the stream
-ends.  It also does some ZoKrates-specific error checking because not all 'errors'
-are supported on 'stderr'
-*/
-const promisifyStream = stream =>
-  new Promise((resolve, reject) => {
-    const MAX_RETURN = 10000000;
-    let chunk = '';
-    stream.on('data', dat => {
-      // chunk += d.toString("utf8").replace(/[^\x40-\x7F]/g, "").replace(/\0/g, '') //remove non-ascii, non alphanumeric
-      chunk += dat.toString('utf8'); // remove any characters that aren't in the proof.
-      if (chunk.length > MAX_RETURN) chunk = '...[truncacted]'; // don't send back too much stuff
-    });
-    stream.on('end', () => {
-      if (chunk.includes('panicked')) {
-        // errors thrown by the application are not always recognised
-        reject(new Error(chunk.slice(chunk.indexOf('panicked'))));
-      } else {
-        resolve(chunk);
-      }
-    });
-    stream.on('error', err => reject(err));
-  });
-
-async function getImportFiles(dataLines) {
+/**
+ * Returns an array of all imported files in dataLines.
+ * @param {String[]} dataLines - Array of lines that make up a .code file.
+ * @returns {String[]} - Array of imported files in dataLines.
+ */
+function getImportFiles(dataLines) {
   const cpDataLines = [...dataLines];
   return cpDataLines.reduce((accArr, line) => {
     // parses each line of the .code file for a line of the form:
@@ -89,405 +46,170 @@ async function getImportFiles(dataLines) {
   }, []);
 }
 
-async function checkForImportFiles(codeFilePath, codeFileName, codeFileParentPath) {
-  console.log(`Checking for 'import' files in the .code file ${codeFileName}`);
-
-  const dataLines = await fs
-    .readFileSync(codeFilePath)
+/**
+ * Ensures that any imported dependencies in code files are present.
+ * @param {String} codeFileDirectory - Directory in which code file resides (i.e., /gm17/ft-burn)
+ * @param {String} codeFile - Name of code file (i.e., ft-burn)
+ * @throws {Error} - If a dependent code file is not found
+ */
+async function checkForImportFiles(codeFileDirectory, codeFile) {
+  const dataLines = fs
+    .readFileSync(`${codeFileDirectory}/${codeFile}`)
     .toString('UTF8')
     .split(os.EOL);
 
+  // Assumes that any dependencies will exist in the /code/gm17 directory.
+  const codeFileParentPath = path.join(codeFileDirectory, '../../');
+
   let importFiles = [];
-  importFiles = await getImportFiles(dataLines);
+  importFiles = getImportFiles(dataLines);
   if (!(importFiles === undefined || importFiles.length === 0)) {
     // array is nonempty
-    const len = importFiles.length;
-    for (let j = 0; i < len; j += 1) {
+    for (let j = 0; j < importFiles.length; j += 1) {
       const file = importFiles[j];
-      try {
-        if (fs.existsSync(codeFileParentPath + file)) {
-          // file exists
-          console.log(`${file} is saved in the correct place`);
-        }
-      } catch (err) {
-        console.error(err);
-        console.error(`${file} not found in ${codeFileParentPath}`);
+      if (!fs.existsSync(codeFileParentPath + file)) {
+        // throw new Error(`Imported file in ${codeFile}: ${file} not found in ${codeFileParentPath}`);
       }
     }
   }
-}
-
-async function setup(codeFile, outputDirPath, backend, a) {
-  const codeFileName = codeFile.substring(0, codeFile.lastIndexOf('.'));
-
-  console.log(`codeFileName: ${codeFileName}`);
-  console.log(`codeFile: ${codeFile}`);
-  console.log(`outputDirPath: ${outputDirPath}`);
-  console.log(`backend: ${backend}`);
-  console.log(`public arguments: ${a}`);
-
-  try {
-    container = await zokrates.runContainerMounted(outputDirPath);
-
-    await container;
-
-    console.log(`\nContainer running for ${codeFileName}`);
-    console.log(`Container id for ${codeFileName}`, `: ${container.id}`);
-    console.log(
-      `To connect to the ${codeFileName}`,
-      ` container manually: 'docker exec -ti ${container.id} bash'`,
-    );
-
-    console.group('\nCompile', codeFileName, '...');
-    // compile .code file
-    let output = await zokrates.compile(container, codeFile).catch(err => {
-      console.error(err);
-    });
-    if (!s) console.log(output);
-    console.log(codeFileName, 'SETUP MESSAGE: COMPILATION COMPLETE');
-    console.groupEnd();
-
-    // optionally run a check on an input string (if parameter -a is specified at runtime)
-    if (a) {
-      console.group('\nComputing witness', codeFileName, '...');
-      output = await zokrates.computeWitness(container, a).catch(err => {
-        console.error(err);
-      });
-      if (!s) console.log(output);
-      const lines = output.split(os.EOL);
-      const cpData = [...lines];
-      // ~out_130
-      let outVals = [];
-      const regex = /(~out_[0-9]+ )([0-9])+/g;
-      cpData
-        .filter(el => el.match(regex))
-        .map(el =>
-          el.replace(/(~out_[0-9]+ )([0-9])+/g, (m, out, _val) => {
-            const val = parseInt(_val, 10); // get the first number
-            outVals = outVals.concat(val);
-          }),
-        );
-      outVals = outVals.reverse(); // the outputs of zokrates are the wrong way around
-
-      let outVal;
-      console.log(outVals);
-      switch (utils.isProbablyBinary(outVals)) {
-        case false:
-          console.log("'field' element detected as output");
-          console.group('\nOutput from compute-witness:\n');
-          console.log(`output array length: ${outVals.length}\n`);
-          console.log(`bin:  ${outVals.forEach(val => utils.decToBin(val))}`);
-          console.log(`dec:  ${outVals}`);
-          console.log(`hex:  ${outVals.forEach(val => utils.decToHex(val))}`);
-          console.groupEnd();
-          break;
-        case true:
-          console.log("'binary' array detected as output");
-          outVal = outVals.join('');
-          console.group('\nOutput from compute-witness:\n');
-          console.log(`output array length: ${outVals.length}\n`);
-          console.log(`bin:  ${outVal}`);
-          console.log(`dec:  ${utils.binToDec(outVal)}`);
-          console.log(`hex:  ${utils.binToHex(outVal)}`);
-          console.groupEnd();
-      }
-      console.log(codeFileName, 'SETUP MESSAGE: CREATE WITNESS COMPLETE');
-      console.groupEnd();
-    } else {
-      // the below runs only if arg '-a' is NOT specified.
-      // i.e. you can either compute a witness by specifying '-a', OR you can create a tar file...
-
-      // trusted setup to produce pk and vk
-      console.group('\nSetup', codeFileName, '...');
-      output = await zokrates.setup(container).catch(err => {
-        console.error(err);
-      });
-      if (!s) console.log(output);
-      console.log('SETUP MESSAGE: SETUP COMPLETE');
-      console.groupEnd();
-
-      // create a verifier.sol
-      console.group('\nExport Verifier', codeFileName, '...');
-      output = await zokrates.exportVerifier(container).catch(err => {
-        console.error(err);
-      });
-      if (!s) console.log(output);
-      console.log(codeFileName, 'SETUP MESSAGE: EXPORT-VERIFIER COMPLETE');
-      console.groupEnd();
-
-      // move the newly created files into your 'code' folder within the zokrates container.
-      const exec = await container.exec
-        .create({
-          Cmd: [
-            '/bin/bash',
-            '-c',
-            `cp ${
-              config.ZOKRATES_OUTPUTS_DIRPATH_ABS
-            }{out,out.code,proving.key,verification.key,verifier.sol} ${
-              config.ZOKRATES_CONTAINER_CODE_DIRPATH_ABS
-            }`,
-          ],
-          AttachStdout: true,
-          AttachStderr: true,
-        })
-        .catch(err => {
-          console.error(err);
-        });
-      output = await promisifyStream(await exec.start());
-      if (!s) console.log(output);
-      console.log(
-        codeFileName,
-        `SETUP MESSAGE: FILES COPIED TO THE MOUNTED DIR WITHIN THE CONTAINER. THE FILES WILL NOW ALSO EXIST WITHIN YOUR LOCALHOST'S FOLDER: ${outputDirPath}`,
-      );
-
-      console.group('\nKey extraction', codeFileName, '...');
-
-      // extract a JSON representation of the vk from the exported Verifier.sol contract.
-      const vkJSON = await keyExtractor.keyExtractor(`${outputDirPath}verifier.sol`, s);
-
-      if (vkJSON) {
-        fs.writeFileSync(`${outputDirPath + codeFileName}-vk.json`, vkJSON, function logErr(err) {
-          if (err) {
-            console.error(err);
-          }
-        });
-        console.log(`File: ${outputDirPath}${codeFileName}-vk.json created successfully`);
-      }
-      console.groupEnd();
-    }
-    if (!d) {
-      console.log(
-        `\nTo connect to the ${codeFileName} container manually: 'docker exec -ti ${
-          container.id
-        } bash'`,
-      );
-    } else {
-      await zokrates.killContainer(container);
-      console.log(`container ${container.id} killed`);
-    }
-
-    console.log(`${codeFileName} SETUP COMPLETE`);
-  } catch (err) {
-    console.log(err);
-    console.log(
-      '\n******************************************************************************************************************',
-      `\nTrusted setup has failed for ${codeFile}. Please see above for additional information relating to this error.`,
-      '\nThe most common cause of errors when using this tool is insufficient allocation of resources to Docker.',
-      "\nYou can go to Docker's settings and increase the RAM being allocated to Docker. See the README for more details.",
-      '\n******************************************************************************************************************',
-    );
-    return new Error(err);
-  }
-  return true; // looks like it worked. Return something for consistency
 }
 
 /**
-@param {string} codeFile A filename string of the form "my-code.code" or "my-code.code"
-@param {string} codeFileParentPath The path to, but not including, the codeFile.
-@param {string} a OPTIONAL A string of arguments, separated by space characters only.
-*/
-async function filingChecks(codeFile, codeFileParentPath) {
-  /**
-  codeFilePath: e.g. "./code/my-code.code"
-  codeFile: e.g. "my-code.code"
-  codeFileName: e.g. "my-code"
-  codeFileExt: e.g. "code"
-  */
-  console.log(`\nFiling checks for codeFile: ${codeFile}`);
-  // check we're working with either a .code file.
-  const codeFileName = await codeFile.substring(0, codeFile.lastIndexOf('.'));
-  const codeFileExt = await codeFile.substring(codeFile.lastIndexOf('.') + 1, codeFile.length);
-  if (!(codeFileExt === 'code')) {
-    return new Error("Invalid file extenstion. Expected a '.code' file.");
-  }
-  const codeFilePath = codeFileParentPath + codeFile;
-  let pwd = process.cwd();
-  pwd += '/code/';
+ * Copies files over to /code/safe-dump, and then checks to ensure imports are present.
+ * @param {string} codeDirectory - Directory that contains the .code file (e.g., '/code/gm17/ft-burn')
+ */
+async function filingChecks(codeDirectory) {
+  const files = await readdirAsync(codeDirectory);
 
-  // A .code file has been specified, but let's copy it into the safe_dump dir in case things go wrong; so we don't lose our original file.
-  try {
-    await fs.copyFileSync(codeFilePath, `${pwd}safe-dump/${codeFile}`);
-    console.log(`${codeFilePath} was copied to safe-dump/${codeFile}`);
-  } catch (err) {
-    return new Error(err);
+  // Looking for the .code file, e.g., ft-burn.out
+  let codeFileName;
+  let codeFileExt;
+  for (let j = 0; j < files.length; j += 1) {
+    codeFileName = files[j].substring(0, files[j].lastIndexOf('.'));
+    codeFileExt = files[j].substring(files[j].lastIndexOf('.') + 1, files[j].length);
+
+    // Output directory
+    // Looking for a .code file, but not out.code
+    if (codeFileExt === 'code' && codeFileName !== 'out') {
+      break;
+    }
   }
 
-  await checkForImportFiles(codeFilePath, codeFileName, codeFileParentPath);
-
-  console.groupEnd();
-  return codeFileName;
-}
-
-function readdirAsync(_path) {
-  return new Promise(function prm(resolve, reject) {
-    fs.readdir(_path, function rdr(error, result) {
-      if (error) {
-        reject(error);
-      } else {
-        resolve(result);
-      }
-    });
-  });
-}
-
-async function checkForOldFiles(dir) {
-  const files = await readdirAsync(dir);
-
-  console.log('\n\nFound existing files:', files, 'in', dir);
-  console.log(
-    "\n\nIf you continue, these files will be deleted (except for the '.code' file and any '.code' dependencies).",
+  // Copies files over to /code/safe-dump
+  const safeDumpDirectory = path.join(codeDirectory, '../../safe-dump');
+  fs.copyFileSync(
+    `${codeDirectory}/${codeFileName}.${codeFileExt}`,
+    `${safeDumpDirectory}/${codeFileName}.${codeFileExt}`,
+    err => {
+      if (err) throw new Error('Error while copying file:', err);
+    },
   );
 
-  const carryOn = await inquirer.prompt([
-    {
-      type: 'skip',
-      name: 'skip',
-      message: 'Continue with the trusted setup? y/n ',
-      choices: ['y', 'n'],
-    },
-  ]);
-  if (carryOn.skip !== 'y') return false;
-
-  return files;
+  await checkForImportFiles(`${codeDirectory}`, `${codeFileName}.${codeFileExt}`);
 }
 
-async function rmOldFiles(dir, files) {
+/**
+ * Given a directory that contains a .code file, calls Zokrates compile, setup and export verifier
+ * @param {String} directoryPath
+ */
+async function generateZokratesFiles(directoryPath) {
+  const files = await readdirAsync(directoryPath);
+
+  const directoryWithSlash = directoryPath.endsWith('/') ? directoryPath : `${directoryPath}/`;
+
+  let codeFile;
+  // Look for a .code file that's not out.code. That's the file we're compiling.
   for (let j = 0; j < files.length; j += 1) {
-    const fileExt = files[j].substring(files[j].lastIndexOf('.') + 1, files[j].length);
-    if ((files[j] === 'out.code')||(fileExt !== 'code')) {
-      console.log('deleting', files[j]);
-      fs.unlink(path.join(dir, files[j]), err => {
-        if (err) throw err;
-      });
+    if (files[j].endsWith('.code') && files[j] !== 'out.code') {
+      codeFile = files[j];
+      break;
     }
   }
-  const remainingFiles = await readdirAsync(dir);
-  console.log('\nFiles remaining:', remainingFiles, 'in', dir);
+
+  console.log('Compiling at', `${directoryWithSlash}${codeFile}`);
+
+  // Generate out.code and out in the same directory.
+  await compile(`${directoryWithSlash}${codeFile}`, directoryWithSlash);
+  console.log('Finished compiling at', directoryPath);
+
+  // Generate verification.key and proving.key
+  await setup(
+    `${directoryWithSlash}out`,
+    directoryWithSlash,
+    'gm17',
+    'verification.key',
+    'proving.key',
+  );
+  console.log('Finished setup at', directoryPath);
+
+  await exportVerifier(
+    `${directoryWithSlash}/verification.key`,
+    directoryWithSlash,
+    'verifier.sol',
+    'gm17',
+  );
+  console.log('Finished export-verifier at', directoryPath);
+
+  const vkJson = await keyExtractor(`${directoryWithSlash}verifier.sol`, true);
+
+  // Create a JSON with the file name but without .code
+  fs.writeFileSync(`${directoryWithSlash}${codeFile.split('.')[0]}-vk.json`, vkJson, err => {
+    if (err) {
+      console.error(err);
+    }
+  });
+  console.log(directoryPath, 'is done setting up.');
 }
 
-// RUN
-async function runSetup(a) {
-  // check we're parsing the correct directory:
-  console.group('Checking pwd...');
-  let pwd = process.cwd();
-  console.log(`pwd: ${pwd}`);
-  const pwdName = pwd.substring(pwd.lastIndexOf('/') + 1, pwd.length);
-  console.log(`pwdName: ${pwdName}`);
-  if (pwdName !== config.ZKP_PWD) {
-    throw new Error(`Wrong PWD. Please call this executable file from: ${config.ZKP_PWD}`);
+/**
+ * Calls Zokrates' compile, setup, and export-verifier on a single directory that contains a .code file.
+ * @param {String} codeDirectory - A specific directory that contains a .code file (e.g., /code/gm17/ft-burn)
+ */
+async function runSetup(codeDirectory) {
+  await filingChecks(codeDirectory);
+
+  await generateZokratesFiles(codeDirectory);
+}
+
+/**
+ * Calls zokrates' compile, setup, and export-verifier on all directories in `/zkp/code/gm17`.
+ * @param {String} codeDirectory - Directory in which all the .code subfolders live.
+ */
+async function runSetupAll(codeDirectory) {
+  // Array of all directories in the above directory.
+  const codeDirectories = getDirectories(codeDirectory);
+
+  await Promise.all(
+    codeDirectories.map(subdirectory => {
+      return filingChecks(subdirectory);
+    }),
+  );
+
+  // The files don't compile correctly when we Promise.all these, so we're doing sequentially.
+  // Maybe too much processing.
+  for (let j = 0; j < codeDirectories.length; j += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await generateZokratesFiles(codeDirectories[j]);
   }
-  pwd += '/code/';
-  console.groupEnd();
+}
 
-  const dir = pwd + i;
-  console.log(`directory: ${dir}`);
+/**
+ * Trusted setup for Nightfall. Either compiles all directories in /code/gm17, or a single directory using the -i flag.
+ */
+async function main() {
+  // arguments to the command line:
+  // i - filename
+  const { i } = argv; // file name - pass the directory of the .code file as the '-i' parameter
 
-  let backend;
-  if (i.indexOf('pghr13') >= 0) {
-    backend = 'pghr13'; // NOTE: although this tool supports PGHR13, the wider Nightfall opensource repo does not support pghr13.
-  } else if (i.indexOf('gm17') >= 0) {
-    backend = 'gm17';
+  // a - arguments for compute-witness
+  const a0 = argv.a; // arguments for compute-witness (within quotes "")
+  let a1 = [];
+  if (!(a0 === undefined || a0 === '')) {
+    a1 = a0.split(' ');
   } else {
-    throw new Error("Incorrect backend or folder specified. Expected either 'pghr13' or 'gm17'.");
+    a1 = null;
   }
 
-  let files = await checkForOldFiles(dir);
-  if (files === false) {
-    throw new Error('user cancelled the setup');
-  }
-  await rmOldFiles(dir, files);
-
-  files = await readdirAsync(dir);
-
-  // filter all files for ones with extension .code
-  files = files.filter(f => {
-    const codeFileExt = f.substring(f.lastIndexOf('.') + 1, f.length);
-    const codeFilePrefix = f.substring(0, 3);
-    if (codeFileExt !== 'code') {
-      return false;
-    }
-    return true;
-  });
-
-  for (let j = 0; j < files.length; j += 1) {
-    const codeFile = files[j];
-    const codeFileParentPath = `${dir}/`;
-    const codeFileName = await filingChecks(codeFile, codeFileParentPath, a); // eslint-disable-line no-await-in-loop
-    await setup(`${codeFileName}.code`, codeFileParentPath, backend, a); // eslint-disable-line no-await-in-loop
-  }
-}
-
-async function runSetupAll(a) {
-  // check we're parsing the correct directory:
-  console.group('Checking pwd...');
-  let pwd = process.cwd();
-  console.log(`pwd: ${pwd}`);
-  const pwdName = pwd.substring(pwd.lastIndexOf('/') + 1, pwd.length);
-  console.log(`pwdName: ${pwdName}`);
-  if (pwdName !== config.ZKP_PWD) {
-    throw new Error(`Wrong PWD. Please call this executable file from: ${config.ZKP_PWD}`);
-  }
-  pwd += '/code/';
-  console.groupEnd();
-
-  let dirs = getDirectories(pwd);
-  console.log('\n\ndirs in', pwd, ':');
-  console.log(dirs);
-
-  // filter dirs to those of interest to us
-  dirs = dirs.filter(dir => {
-    const dirName = dir.substring(dir.lastIndexOf('/') + 1, dir.length);
-    if (dirName === 'gm17') {
-      return true;
-    }
-    return false;
-  });
-  console.log('\n\nrelevant dirs in', pwd, ':');
-  console.log(dirs);
-  // get the dirs within the dirs
-  const dirs2 = [];
-  // get the files within the dirs
-  for (let k = 0; k < dirs.length; k += 1) {
-    dirs2[k] = getDirectories(dirs[k]);
-    console.log('\n\ndirs in', dirs[k], ':');
-    console.log(dirs2[k]);
-
-    for (let l = 0; l < dirs2[k].length; l += 1) {
-      const dir = dirs[k];
-      const dir2 = dirs2[k][l];
-
-      let files = await checkForOldFiles(dir2); // eslint-disable-line no-await-in-loop
-      if (files !== []) {
-        await rmOldFiles(dir2, files); // eslint-disable-line no-await-in-loop
-        files = await readdirAsync(dir2); // eslint-disable-line no-await-in-loop
-        // filter all files for ones with extension .code
-        files = files.filter(f => {
-          const codeFileExt = f.substring(f.lastIndexOf('.') + 1, f.length);
-          const codeFilePrefix = f.substring(0, 3);
-          if (codeFileExt !== 'code') {
-            return false;
-          }
-          return true;
-        });
-        for (let j = 0; j < files.length; j += 1) {
-          const codeFile = files[j];
-          const codeFileParentPath = `${dir2}/`;
-          const backend = dir.substring(dir.lastIndexOf('/') + 1, dir.length);
-          const codeFileName = await filingChecks(codeFile, codeFileParentPath, a); // eslint-disable-line no-await-in-loop
-
-          try {
-            await setup(`${codeFileName}.code`, codeFileParentPath, backend, a); // eslint-disable-line no-await-in-loop
-          } catch (err) {
-            console.log(err);
-            break;
-          }
-        }
-      }
-    }
-  }
-}
-
-async function allOrOne() {
   if (!i) {
     console.log(
       "The '-i' option has not been specified.\nThat's OK, we can go ahead and loop through every .code file.\nHOWEVER, if you wanted to choose just one file, cancel this process, and instead use option -i (see the README-trusted-setup)",
@@ -505,9 +227,9 @@ async function allOrOne() {
     if (carryOn.continue !== 'y') return;
 
     try {
-      runSetupAll(a1); // we'll do all .code files if no option is specified
+      await runSetupAll(`${process.cwd()}/code/gm17`); // we'll do all .code files if no option is specified
     } catch (err) {
-      throw new Error(`${err}Trusted setup failed.`);
+      throw new Error(`Trusted setup failed: ${err}`);
     }
   } else {
     await runSetup(a1);
@@ -515,4 +237,4 @@ async function allOrOne() {
 }
 
 // RUN
-allOrOne().catch(err => console.log(err));
+main().catch(err => console.log(err));

--- a/zkp/code/keyExtractor.js
+++ b/zkp/code/keyExtractor.js
@@ -11,7 +11,7 @@ import os from 'os';
 @param {string} solFilePath
 @param {argv} s OPTIONAL argv which suppresses lengthy console outputs
 */
-async function keyExtractor(solFilePath, s) {
+export default async function keyExtractor(solFilePath, s) {
   const solData = fs
     .readFileSync(solFilePath)
     .toString('UTF8')
@@ -52,7 +52,3 @@ async function keyExtractor(solFilePath, s) {
   if (!s) console.log(jsonTxt.join('\n'));
   return jsonTxt.join('\n');
 }
-
-export default {
-  keyExtractor,
-};

--- a/zkp/package-lock.json
+++ b/zkp/package-lock.json
@@ -855,9 +855,9 @@
       }
     },
     "@eyblockchain/zokrates.js": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@eyblockchain/zokrates.js/-/zokrates.js-1.1.5.tgz",
-      "integrity": "sha512-TuAAa6c/MOMuo2Lsc1SPJQVOgxGl+LYjOCy/zMbyMtpCmfGaYteCvj7PFcw3ojFha0bLpIXnu4g8rjM4oIDPRQ=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@eyblockchain/zokrates.js/-/zokrates.js-1.2.0.tgz",
+      "integrity": "sha512-R/bEmqJbYF9EcXatn1xT499M8BfVIlK/DkPyd7RMNRWiQ5D1/MHSHRWomHsbvaQVaAnLZap+zc6lc5J111i7Ng=="
     },
     "@jest/console": {
       "version": "24.7.1",
@@ -1514,6 +1514,11 @@
       "resolved": "https://registry.npmjs.org/beepbeep/-/beepbeep-1.2.2.tgz",
       "integrity": "sha512-6Kz/q06tpY/rMlB+vmq1vFGkGwfSolJlbxR3QUZOFSlPSfYUpPMo43o25xu6ou1GaoTiXV8adlelhewilup0Ag=="
     },
+    "big-integer": {
+      "version": "1.6.47",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.47.tgz",
+      "integrity": "sha512-9t9f7X3as2XGX8b52GqG6ox0GvIdM86LyIXASJnDCFhYNgt+A+MByQZ3W2PyMRZjEvG5f8TEbSPfEotVuMJnQg=="
+    },
     "bignumber.js": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-8.1.1.tgz",
@@ -1567,6 +1572,13 @@
             "safe-buffer": "~5.1.1",
             "string_decoder": "~1.1.1",
             "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
           }
         },
         "string_decoder": {
@@ -1575,6 +1587,13 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
           }
         }
       }
@@ -2115,6 +2134,13 @@
       "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
       "requires": {
         "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "content-type": {
@@ -2129,6 +2155,14 @@
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        }
       }
     },
     "cookie": {
@@ -2960,6 +2994,13 @@
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "extend": {
@@ -5577,6 +5618,14 @@
             "safe-buffer": "~5.1.1",
             "string_decoder": "~1.1.1",
             "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            }
           }
         },
         "string_decoder": {
@@ -5586,6 +5635,14 @@
           "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            }
           }
         }
       }
@@ -6633,6 +6690,14 @@
             "safe-buffer": "~5.1.1",
             "string_decoder": "~1.1.1",
             "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            }
           }
         },
         "string_decoder": {
@@ -6642,6 +6707,14 @@
           "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            }
           }
         }
       }
@@ -6938,9 +7011,9 @@
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -7638,6 +7711,13 @@
             "safe-buffer": "~5.1.1",
             "string_decoder": "~1.1.1",
             "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
           }
         },
         "string_decoder": {
@@ -7646,6 +7726,13 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+            }
           }
         }
       }
@@ -9103,6 +9190,13 @@
         "async-limiter": "~1.0.0",
         "safe-buffer": "~5.1.0",
         "ultron": "~1.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
       }
     },
     "xdg-basedir": {

--- a/zkp/package-lock.json
+++ b/zkp/package-lock.json
@@ -854,6 +854,11 @@
         }
       }
     },
+    "@eyblockchain/zokrates.js": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@eyblockchain/zokrates.js/-/zokrates.js-1.1.5.tgz",
+      "integrity": "sha512-TuAAa6c/MOMuo2Lsc1SPJQVOgxGl+LYjOCy/zMbyMtpCmfGaYteCvj7PFcw3ojFha0bLpIXnu4g8rjM4oIDPRQ=="
+    },
     "@jest/console": {
       "version": "24.7.1",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.7.1.tgz",
@@ -8610,7 +8615,19 @@
           "requires": {
             "underscore": "1.8.3",
             "web3-core-helpers": "1.0.0-beta.36",
-            "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
+            "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
+          },
+          "dependencies": {
+            "websocket": {
+              "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+              "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+              "requires": {
+                "debug": "^2.2.0",
+                "nan": "^2.3.3",
+                "typedarray-to-buffer": "^3.1.2",
+                "yaeti": "^0.0.6"
+              }
+            }
           }
         },
         "web3-shh": {
@@ -8915,19 +8932,7 @@
       "requires": {
         "underscore": "1.8.3",
         "web3-core-helpers": "1.0.0-beta.37",
-        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
-      },
-      "dependencies": {
-        "websocket": {
-          "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
-          "requires": {
-            "debug": "^2.2.0",
-            "nan": "^2.3.3",
-            "typedarray-to-buffer": "^3.1.2",
-            "yaeti": "^0.0.6"
-          }
-        }
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
       }
     },
     "web3-shh": {
@@ -8967,6 +8972,16 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
       "dev": true
+    },
+    "websocket": {
+      "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+      "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+      "requires": {
+        "debug": "^2.2.0",
+        "nan": "^2.3.3",
+        "typedarray-to-buffer": "^3.1.2",
+        "yaeti": "^0.0.6"
+      }
     },
     "whatwg-encoding": {
       "version": "1.0.5",

--- a/zkp/package.json
+++ b/zkp/package.json
@@ -8,8 +8,7 @@
     "setup": "NODE_ENV=setup npx babel-node code/index.js",
     "setup-all": "yes | NODE_ENV=setup npx babel-node code/index.js",
     "start": "nodemon --ignore src/vkIds.json --ignore stats-config/ --ignore code/ --exec babel-node ./src/index.js",
-    "test": "jest --runInBand --verbose --forceExit ./__tests__/*.test.js",
-    "generate-keys": "./install.sh"
+    "test": "NODE_ENV=default jest --runInBand --forceExit ./__tests__/*.test.js"
   },
   "contributors": [
     "Chaitanya Konda <CKonda@uk.ey.com>",
@@ -23,6 +22,7 @@
   ],
   "license": "CC0-1.0",
   "dependencies": {
+    "@eyblockchain/zokrates.js": "^1.1.5",
     "beepbeep": "1.2.2",
     "bignumber.js": "^8.0.2",
     "body-parser": "^1.19.0",

--- a/zkp/package.json
+++ b/zkp/package.json
@@ -22,8 +22,9 @@
   ],
   "license": "CC0-1.0",
   "dependencies": {
-    "@eyblockchain/zokrates.js": "^1.1.5",
+    "@eyblockchain/zokrates.js": "^1.2.0",
     "beepbeep": "1.2.2",
+    "big-integer": "^1.6.47",
     "bignumber.js": "^8.0.2",
     "body-parser": "^1.19.0",
     "config": "^3.2.2",
@@ -35,6 +36,7 @@
     "jsonfile": "^4.0.0",
     "left-pad": "^1.3.0",
     "node-docker-api": "^1.1.22",
+    "safe-buffer": "^5.2.0",
     "truffle-contract": "4.0.15",
     "web3": "1.0.0-beta.36",
     "yargs": "^12.0.1"

--- a/zkp/src/Element.js
+++ b/zkp/src/Element.js
@@ -1,6 +1,5 @@
 import config from 'config';
-
-const utils = require('zkp-utils');
+import utils from './zkpUtils';
 
 /**
 This class defines a 'proof element'.  That's basically an object that will be fed

--- a/zkp/src/compute-vectors.js
+++ b/zkp/src/compute-vectors.js
@@ -6,8 +6,7 @@
 
 import config from 'config';
 import zkp from './nf-token-zkp';
-
-const utils = require('zkp-utils');
+import utils from './zkpUtils';
 
 /**
 function to compute the sequence of numbers that go after the 'a' in

--- a/zkp/src/f-token-controller.js
+++ b/zkp/src/f-token-controller.js
@@ -16,8 +16,7 @@ import cv from './compute-vectors';
 import Element from './Element';
 import Web3 from './web3';
 import { getContract } from './contractUtils';
-
-const utils = require('zkp-utils');
+import utils from './zkpUtils';
 
 const FTokenShield = contract(jsonfile.readFileSync('./build/contracts/FTokenShield.json'));
 FTokenShield.setProvider(Web3.connect());

--- a/zkp/src/f-token-zkp.js
+++ b/zkp/src/f-token-zkp.js
@@ -7,15 +7,7 @@ before it will work. This version works by transforming an existing commitment t
 new one, which enables sending of arbritrary amounts. The code also talks directly to Verifier.
 */
 
-const utils = require('zkp-utils');
-
-/**
-This function loads the verifying key data into the verifier registry smart contract
-@param {array} vk - array containing the data to load.
-@param {string} account - the account that is paying for the transactions
-@param {contract} verifier - an instance of the verifier smart contract
-@param {contract} verifierRegistry - an instance of the verifierRegistry smart contract
-*/
+import utils from './zkpUtils';
 
 /**
 checks the details of an incoming (newly transferred token), to ensure the data we have received is correct and legitimate!!

--- a/zkp/src/nf-token-controller.js
+++ b/zkp/src/nf-token-controller.js
@@ -9,8 +9,8 @@ rest api calls, and the heavy-lifitng token-zkp.js and zokrates.js.  It exists s
 
 import contract from 'truffle-contract';
 import jsonfile from 'jsonfile';
-import utils from 'zkp-utils';
 import config from 'config';
+import utils from './zkpUtils';
 import zkp from './nf-token-zkp';
 import zokrates from './zokrates';
 import cv from './compute-vectors';

--- a/zkp/src/nf-token-zkp.js
+++ b/zkp/src/nf-token-zkp.js
@@ -7,8 +7,8 @@ will work. This version works by transforming an existing commitment to a new on
 enables multiple transfers of an asset to take place. The code also talks directly to Verifier.
 */
 
-import utils from 'zkp-utils';
 import config from 'config';
+import utils from './zkpUtils';
 
 /**
 @notice gets a node from the merkle tree data from the nfTokenShield contract.

--- a/zkp/src/routes/ft-commitment.js
+++ b/zkp/src/routes/ft-commitment.js
@@ -1,7 +1,7 @@
 /* eslint-disable camelcase */
 
 import { Router } from 'express';
-import utils from 'zkp-utils';
+import utils from '../zkpUtils';
 import fTokenController from '../f-token-controller';
 import { getVkId, getContract } from '../contractUtils';
 

--- a/zkp/src/vk-controller.js
+++ b/zkp/src/vk-controller.js
@@ -8,8 +8,8 @@ rest api calls, and the heavy-lifitng token-zkp.js and zokrates.js.  It exists s
 import contract from 'truffle-contract';
 import jsonfile from 'jsonfile';
 import fs from 'fs';
-import utils from 'zkp-utils';
 import config from 'config';
+import utils from './zkpUtils';
 import Web3 from './web3';
 
 const NFtokenShield = contract(jsonfile.readFileSync('./build/contracts/NFTokenShield.json'));

--- a/zkp/src/zkpUtils.js
+++ b/zkp/src/zkpUtils.js
@@ -1,0 +1,555 @@
+/**
+@module utils.js
+@author Westlad,Chaitanya-Konda,iAmMichaelConnor
+@desc Set of utilities to manipulate variable into forms most liked by
+Ethereum and Zokrates
+*/
+
+import BI from 'big-integer';
+import hexToBinary from 'hex-to-binary';
+import crypto from 'crypto';
+import { Buffer } from 'safe-buffer';
+
+const inputsHashLength = 32;
+const merkleDepth = 33;
+
+// FUNCTIONS ON HEX VALUES
+
+/**
+utility function to remove a leading 0x on a string representing a hex number.
+If no 0x is present then it returns the string un-altered.
+*/
+function strip0x(hex) {
+  if (typeof hex === 'undefined') return '';
+  if (typeof hex === 'string' && hex.indexOf('0x') === 0) {
+    return hex.slice(2).toString();
+  }
+  return hex.toString();
+}
+
+function isHex(h) {
+  const regexp = /^[0-9a-fA-F]+$/;
+  return regexp.test(strip0x(h));
+}
+
+/**
+utility function to check that a string has a leading 0x (which the Solidity
+compiler uses to check for a hex string).  It adds it if it's not present. If
+it is present then it returns the string unaltered
+*/
+function ensure0x(hex = '') {
+  const hexString = hex.toString();
+  if (typeof hexString === 'string' && hexString.indexOf('0x') !== 0) {
+    return `0x${hexString}`;
+  }
+  return hexString;
+}
+
+/**
+Utility function to convert a string into a hex representation of fixed length.
+@param {string} str - the string to be converted
+@param {int} outLength - the length of the output hex string in bytes (excluding the 0x)
+if the string is too short to fill the output hex string, it is padded on the left with 0s
+if the string is too long, an error is thrown
+*/
+function utf8StringToHex(str, outLengthBytes) {
+  const outLength = outLengthBytes * 2; // work in characters rather than bytes
+  const buf = Buffer.from(str, 'utf8');
+  let hex = buf.toString('hex');
+  if (outLength < hex.length)
+    throw new Error('String is to long, try increasing the length of the output hex');
+  hex = hex.padStart(outLength, '00');
+  return ensure0x(hex);
+}
+
+function hexToUtf8String(hex) {
+  const cleanHex = strip0x(hex).replace(/00/g, '');
+
+  const buf = Buffer.from(cleanHex, 'hex');
+  return buf.toString('utf8');
+}
+
+/**
+Converts hex strings into binary, so that they can be passed into merkle-proof.code
+for example (0xff -> [1,1,1,1,1,1,1,1])
+*/
+function hexToBin(hex) {
+  return hexToBinary(strip0x(hex)).split('');
+}
+
+/** Helper function for the converting any base to any base
+ */
+function parseToDigitsArray(str, base) {
+  const digits = str.split('');
+  const ary = [];
+  for (let i = digits.length - 1; i >= 0; i -= 1) {
+    const n = parseInt(digits[i], base);
+    if (Number.isNaN(n)) return null;
+    ary.push(n);
+  }
+  return ary;
+}
+
+/** Helper function for the converting any base to any base
+ */
+function add(x, y, base) {
+  const z = [];
+  const n = Math.max(x.length, y.length);
+  let carry = 0;
+  let i = 0;
+  while (i < n || carry) {
+    const xi = i < x.length ? x[i] : 0;
+    const yi = i < y.length ? y[i] : 0;
+    const zi = carry + xi + yi;
+    z.push(zi % base);
+    carry = Math.floor(zi / base);
+    i += 1;
+  }
+  return z;
+}
+
+/** Helper function for the converting any base to any base
+ Returns a*x, where x is an array of decimal digits and a is an ordinary
+ JavaScript number. base is the number base of the array x.
+*/
+function multiplyByNumber(num, x, base) {
+  if (num < 0) return null;
+  if (num === 0) return [];
+
+  let result = [];
+  let power = x;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    // eslint-disable-next-line no-bitwise
+    if (num & 1) {
+      result = add(result, power, base);
+    }
+    num >>= 1; // eslint-disable-line
+    if (num === 0) break;
+    power = add(power, power, base);
+  }
+  return result;
+}
+
+/** Helper function for the converting any base to any base
+ */
+function convertBase(str, fromBase, toBase) {
+  const digits = parseToDigitsArray(str, fromBase);
+  if (digits === null) return null;
+
+  let outArray = [];
+  let power = [1];
+  for (let i = 0; i < digits.length; i += 1) {
+    // invariant: at this point, fromBase^i = power
+    if (digits[i]) {
+      outArray = add(outArray, multiplyByNumber(digits[i], power, toBase), toBase);
+    }
+    power = multiplyByNumber(fromBase, power, toBase);
+  }
+
+  let out = '';
+  for (let i = outArray.length - 1; i >= 0; i -= 1) {
+    out += outArray[i].toString(toBase);
+  }
+  // if the original input was equivalent to zero, then 'out' will still be empty ''. Let's check for zero.
+  if (out === '') {
+    let sum = 0;
+    for (let i = 0; i < digits.length; i += 1) {
+      sum += digits[i];
+    }
+    if (sum === 0) out = '0';
+  }
+
+  return out;
+}
+
+// the hexToBinary library was giving some funny values with 'undefined' elements within the binary string. Using convertBase seems to be working nicely. THe 'Simple' suffix is to distinguish from hexToBin, which outputs an array of bit elements.
+function hexToBinSimple(hex) {
+  const bin = convertBase(strip0x(hex), 16, 2);
+  return bin;
+}
+
+/**
+Converts hex strings into byte (decimal) values.  This is so that they can
+be passed into  merkle-proof.code in a more compressed fromat than bits.
+Each byte is invididually converted so 0xffff becomes [15,15]
+*/
+function hexToBytes(hex) {
+  const cleanHex = strip0x(hex);
+  const out = [];
+  for (let i = 0; i < cleanHex.length; i += 2) {
+    const h = ensure0x(cleanHex[i] + cleanHex[i + 1]);
+    out.push(parseInt(h, 10).toString());
+  }
+  return out;
+}
+
+// Converts hex strings to decimal values
+function hexToDec(hexStr) {
+  if (hexStr.substring(0, 2) === '0x') {
+    return convertBase(hexStr.substring(2).toLowerCase(), 16, 10);
+  }
+  return convertBase(hexStr.toLowerCase(), 16, 10);
+}
+
+/** converts a hex string to an element of a Finite Field GF(fieldSize) (note, decimal representation is used for all field elements)
+@param {string} hexStr A hex string.
+@param {integer} fieldSize The number of elements in the finite field.
+@return {string} A Field Value (decimal value) (formatted as string, because they're very large)
+*/
+function hexToField(hexStr, fieldSize) {
+  const cleanHexStr = strip0x(hexStr);
+  const decStr = hexToDec(cleanHexStr);
+  const q = BI(fieldSize);
+  return BI(decStr)
+    .mod(q)
+    .toString();
+}
+
+/**
+Left-pads the input hex string with zeros, so that it becomes of size N octets.
+@param {string} hexStr A hex number/string.
+@param {integer} N The string length (i.e. the number of octets).
+@return A hex string (padded) to size N octets, (plus 0x at the start).
+*/
+function leftPadHex(hexStr, n) {
+  return ensure0x(strip0x(hexStr).padStart(n, '0'));
+}
+
+/**
+Used by splitAndPadBitsN function.
+Left-pads the input binary string with zeros, so that it becomes of size N bits.
+@param {string} bitStr A binary number/string.
+@param {integer} N The 'chunk size'.
+@return A binary string (padded) to size N bits.
+*/
+function leftPadBitsN(bitStr, n) {
+  const len = bitStr.length;
+  let paddedStr;
+  if (len > n) {
+    return new Error(`String larger than ${n} bits passed to leftPadBitsN`);
+  }
+  if (len === n) {
+    return bitStr;
+  }
+  paddedStr = '0'.repeat(n - len);
+  paddedStr = paddedStr.toString() + bitStr.toString();
+  return paddedStr;
+}
+
+/**
+Used by split'X'ToBitsN functions.
+Checks whether a binary number is larger than N bits, and splits its binary representation into chunks of size = N bits. The left-most (big endian) chunk will be the only chunk of size <= N bits. If the inequality is strict, it left-pads this left-most chunk with zeros.
+@param {string} bitStr A binary number/string.
+@param {integer} N The 'chunk size'.
+@return An array whose elements are binary 'chunks' which altogether represent the input binary number.
+*/
+function splitAndPadBitsN(bitStr, n) {
+  let a = [];
+  const len = bitStr.length;
+  if (len <= n) {
+    return [leftPadBitsN(bitStr, n)];
+  }
+  const nStr = bitStr.slice(-n); // the rightmost N bits
+  const remainderStr = bitStr.slice(0, len - n); // the remaining rightmost bits
+
+  a = [...splitAndPadBitsN(remainderStr, n), nStr, ...a];
+
+  return a;
+}
+
+/** Checks whether a hex number is larger than N bits, and splits its binary representation into chunks of size = N bits. The left-most (big endian) chunk will be the only chunk of size <= N bits. If the inequality is strict, it left-pads this left-most chunk with zeros.
+@param {string} hexStr A hex number/string.
+@param {integer} N The 'chunk size'.
+@return An array whose elements are binary 'chunks' which altogether represent the input hex number.
+*/
+function splitHexToBitsN(hexStr, n) {
+  const strippedHexStr = strip0x(hexStr);
+  const bitStr = hexToBinSimple(strippedHexStr.toString());
+  let a = [];
+  a = splitAndPadBitsN(bitStr, n);
+  return a;
+}
+
+// Converts binary value strings to decimal values
+function binToDec(binStr) {
+  const dec = convertBase(binStr, 2, 10);
+  return dec;
+}
+
+/** Preserves the magnitude of a hex number in a finite field, even if the order of the field is smaller than hexStr. hexStr is converted to decimal (as fields work in decimal integer representation) and then split into chunks of size packingSize. Relies on a sensible packing size being provided (ZoKrates uses packingSize = 128).
+ *if the result has fewer elements than it would need for compatibiity with the dsl, it's padded to the left with zero elements
+ */
+function hexToFieldPreserve(hexStr, packingSize, packets, silenceWarnings) {
+  let bitsArr = [];
+  bitsArr = splitHexToBitsN(strip0x(hexStr).toString(), packingSize.toString());
+
+  let decArr = []; // decimal array
+  decArr = bitsArr.map(item => binToDec(item.toString()));
+
+  // fit the output array to the desired number of packets:
+  if (packets !== undefined) {
+    if (packets < decArr.length) {
+      const overflow = decArr.length - packets;
+      if (!silenceWarnings)
+        throw new Error(
+          `Field split into an array of ${decArr.length} packets: ${decArr}
+          , but this exceeds the requested packet size of ${packets}. Data would have been lost; possibly unexpectedly. To silence this warning, pass '1' or 'true' as the final parameter.`,
+        );
+      // remove extra packets (dangerous!):
+      for (let i = 0; i < overflow; i += 1) decArr.shift();
+    } else {
+      const missing = packets - decArr.length;
+      // add any missing zero elements
+      for (let i = 0; i < missing; i += 1) decArr.unshift('0');
+    }
+  }
+  return decArr;
+}
+
+// Converts binary value strings to hex values
+function binToHex(binStr) {
+  const hex = convertBase(binStr, 2, 16);
+  return hex ? `0x${hex}` : null;
+}
+
+// FUNCTIONS ON DECIMAL VALUES
+
+// Converts decimal value strings to hex values
+function decToHex(decStr) {
+  const hex = convertBase(decStr, 10, 16);
+  return hex ? `0x${hex}` : null;
+}
+
+// Converts decimal value strings to binary values
+function decToBin(decStr) {
+  return convertBase(decStr, 10, 2);
+}
+
+/** Checks whether a decimal integer is larger than N bits, and splits its binary representation into chunks of size = N bits. The left-most (big endian) chunk will be the only chunk of size <= N bits. If the inequality is strict, it left-pads this left-most chunk with zeros.
+@param {string} decStr A decimal number/string.
+@param {integer} N The 'chunk size'.
+@return An array whose elements are binary 'chunks' which altogether represent the input decimal number.
+*/
+function splitDecToBitsN(decStr, N) {
+  const bitStr = decToBin(decStr.toString());
+  let a = [];
+  a = splitAndPadBitsN(bitStr, N);
+  return a;
+}
+
+function isProbablyBinary(arr) {
+  const foundField = arr.find(el => el !== 0 && el !== 1);
+  // ...hence it is not binary:
+  return !foundField;
+}
+
+// FUNCTIONS ON FIELDS
+
+/**
+Converts an array of Field Elements (decimal numbers which are smaller in magnitude than the field size q), where the array represents a decimal of magnitude larger than q, into the decimal which the array represents.
+@param {[string]} fieldsArr is an array of (decimal represented) field elements. Each element represents a number which is 2**128 times larger than the next in the array. So the 0th element of fieldsArr requires the largest left-shift (by a multiple of 2**128), and the last element is not shifted (shift = 1). The shifted elements should combine (sum) to the underlying decimal number which they represent.
+@param {integer} packingSize Each field element of fieldsArr is a 'packing' of exactly 'packingSize' bits. I.e. packingSize is the size (in bits) of each chunk (element) of fieldsArr. We use this to reconstruct the underlying decimal value which was, at some point previously, packed into a fieldsArr format.
+@returns {string} A decimal number (as a string, because it might be a very large number)
+*/
+function fieldsToDec(fieldsArr, packingSize) {
+  const len = fieldsArr.length;
+  let acc = new BI('0');
+  const s = [];
+  const t = [];
+  const shift = [];
+  const exp = new BI(2).pow(packingSize);
+  for (let i = 0; i < len; i += 1) {
+    s[i] = new BI(fieldsArr[i].toString());
+    shift[i] = new BI(exp).pow(len - 1 - i); // binary shift of the ith field element
+    t[i] = new BI('0');
+    t[i] = s[i].multiply(shift[i]);
+    acc = acc.add(t[i]);
+  }
+  const decStr = acc.toString();
+  return decStr;
+}
+
+// UTILITY FUNCTIONS:
+
+/**
+Utility function to xor to two hex strings and return as buffer
+Looks like the inputs are somehow being changed to decimal!
+*/
+function xor(a, b) {
+  const length = Math.max(a.length, b.length);
+  const buffer = Buffer.allocUnsafe(length); // creates a buffer object of length 'length'
+  for (let i = 0; i < length; i += 1) {
+    buffer[i] = a[i] ^ b[i]; // eslint-disable-line
+  }
+  // a.forEach((item)=>console.log("xor input a: " + item))
+  // b.forEach((item)=>console.log("xor input b: " + item))
+  // buffer.forEach((item)=>console.log("xor outputs: " + item))
+  return buffer;
+}
+
+/**
+Utility function to concatenate two hex strings and return as buffer
+Looks like the inputs are somehow being changed to decimal!
+*/
+function concatenate(a, b) {
+  const length = a.length + b.length;
+  const buffer = Buffer.allocUnsafe(length); // creates a buffer object of length 'length'
+  for (let i = 0; i < a.length; i += 1) {
+    buffer[i] = a[i];
+  }
+  for (let j = 0; j < b.length; j += 1) {
+    buffer[a.length + j] = b[j];
+  }
+  return buffer;
+}
+
+/**
+Utility function:
+hashes a concatenation of items but it does it by
+breaking the items up into 432 bit chunks, hashing those, plus any remainder
+and then repeating the process until you end up with a single hash.  That way
+we can generate a hash without needing to use more than a single sha round.  It's
+not the same value as we'd get using rounds but it's at least doable.
+*/
+function hash(item) {
+  const preimage = strip0x(item);
+
+  const h = `0x${crypto
+    .createHash('sha256')
+    .update(preimage, 'hex')
+    .digest('hex')
+    .slice(-(inputsHashLength * 2))}`;
+  return h;
+}
+
+/**
+Utility function to:
+- convert each item in items to a 'buffer' of bytes (2 hex values), convert those bytes into decimal representation
+- 'concatenate' each decimally-represented byte together into 'concatenated bytes'
+- hash the 'buffer' of 'concatenated bytes' (sha256) (sha256 returns a hex output)
+- truncate the result to the right-most 64 bits
+Return:
+createHash: we're creating a sha256 hash
+update: [input string to hash (an array of bytes (in decimal representaion) [byte, byte, ..., byte] which represents the result of: item1, item2, item3. Note, we're calculating hash(item1, item2, item3) ultimately]
+digest: [output format ("hex" in our case)]
+slice: [begin value] outputs the items in the array on and after the 'begin value'
+*/
+function concatenateThenHash(...items) {
+  const concatvalue = items
+    .map(item => Buffer.from(strip0x(item), 'hex'))
+    .reduce((acc, item) => concatenate(acc, item));
+
+  const h = `0x${crypto
+    .createHash('sha256')
+    .update(concatvalue, 'hex')
+    .digest('hex')}`;
+  return h;
+}
+
+/**
+function to generate a promise that resolves to a string of hex
+@param {int} bytes - the number of bytes of hex that should be returned
+*/
+function rndHex(bytes) {
+  return new Promise((resolve, reject) => {
+    crypto.randomBytes(bytes, (err, buf) => {
+      if (err) reject(err);
+      resolve(`0x${buf.toString('hex')}`);
+    });
+  });
+}
+
+function getLeafIndexFromZCount(zCount) {
+  // force it to be a number:
+  const zCountInt = parseInt(zCount, 10);
+  const MERKLE_DEPTH = parseInt(merkleDepth, 10);
+  const MERKLE_WIDTH = parseInt(2 ** (MERKLE_DEPTH - 1), 10);
+  const leafIndex = parseInt(MERKLE_WIDTH - 1 + zCountInt, 10);
+  return leafIndex;
+}
+
+/* flattenDeep converts a nested array into a flattened array. We use this to pass our proofs and vks into the verifier contract.
+Example:
+A vk of the form:
+[
+  [
+    [ '1','2' ],
+    [ '3','4' ]
+  ],
+    [ '5','6' ],
+    [
+      [ '7','8' ], [ '9','10' ]
+    ],
+  [
+    [ '11','12' ],
+    [ '13','14' ]
+  ],
+    [ '15','16' ],
+    [
+      [ '17','18' ], [ '19','20' ]
+    ],
+  [
+    [ '21','22' ],
+    [ '23','24' ]
+  ],
+  [
+    [ '25','26' ],
+    [ '27','28' ],
+    [ '29','30' ],
+    [ '31','32' ]
+  ]
+]
+
+is converted to:
+['1','2','3','4','5','6',...]
+*/
+function flattenDeep(arr) {
+  return arr.reduce(
+    (acc, val) => (Array.isArray(val) ? acc.concat(flattenDeep(val)) : acc.concat(val)),
+    [],
+  );
+}
+
+// function to pad out a Hex value with leading zeros to l bits total length,
+// preserving the '0x' at the start
+function padHex(A, l) {
+  if (l % 8 !== 0) throw new Error('cannot convert bits into a whole number of bytes');
+  return ensure0x(strip0x(A).padStart(l / 4, '0'));
+}
+
+module.exports = {
+  isHex,
+  utf8StringToHex,
+  hexToUtf8String,
+  ensure0x,
+  strip0x,
+  hexToBin,
+  hexToBinSimple,
+  hexToBytes,
+  hexToDec,
+  hexToField,
+  hexToFieldPreserve,
+  decToHex,
+  decToBin,
+  binToDec,
+  binToHex,
+  isProbablyBinary,
+  fieldsToDec,
+  xor,
+  concatenate,
+  hash,
+  concatenateThenHash,
+  add,
+  parseToDigitsArray,
+  convertBase,
+  splitDecToBitsN,
+  splitHexToBitsN,
+  splitAndPadBitsN,
+  leftPadBitsN,
+  getLeafIndexFromZCount,
+  rndHex,
+  flattenDeep,
+  padHex,
+  leftPadHex,
+};


### PR DESCRIPTION
This PR uses zokrates.js instead of the nested docker container. This greatly simplifies a lot of the logic, and makes the code a lot cleaner to read.

I wasn't sure about how much of the filingChecks functionality was still used, I left it all in but maybe we could remove it if it's legacy code.