### PR TITLE
(bug fix) ft commitment transfer page - no negative number allowed

### DIFF
--- a/ui/src/app/pages/ft-commitment-transfer/index.html
+++ b/ui/src/app/pages/ft-commitment-transfer/index.html
@@ -61,6 +61,9 @@
             <div class="col-md-6">
               <input
                 type="number"
+                min="0"
+                (keypress)="utilService.noNegtiveNumber($event)"
+                (paste)="utilService.noNegtiveNumber($event)"
                 class="form-control"
                 [(ngModel)]="transferValue"
                 name="E"

--- a/ui/src/app/services/utils/util.service.ts
+++ b/ui/src/app/services/utils/util.service.ts
@@ -65,5 +65,12 @@ export class UtilService {
     }
   }
 
-
+  noNegtiveNumber(evt) {
+    let value;
+    if (evt.type !== 'paste') {
+      value = evt.key;
+    }  
+    if(isNaN(value)) return evt.returnValue = false;
+    if(Number(value) < 0) return evt.returnValue = false;
+  }
 }


### PR DESCRIPTION
# Description
fixes to UI ft-commitment-transfer page. Now no negative value allowed to transfer from UI

## Related Issue
fixes #276 


## How Has This Been Tested
by running UI

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.