### PR TITLE
Remove unused zkp-util code

### DIFF
--- a/zkp-utils/index.js
+++ b/zkp-utils/index.js
@@ -120,8 +120,10 @@ function multiplyByNumber(num, x, base) {
 
   let result = [];
   let power = x;
-  while (true) { // eslint-disable-line
-    if (num & 1) { // eslint-disable-line
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    // eslint-disable-next-line no-bitwise
+    if (num & 1) {
       result = add(result, power, base);
     }
     num >>= 1; // eslint-disable-line
@@ -307,51 +309,13 @@ function hexToFieldPreserve(hexStr, packingSize, packets, silenceWarnings) {
   return decArr;
 }
 
-/**
-checks whether a hex string is smaller than a finite field size.
-@param {string} hexStr A hex string.
-@param {integer} fieldSize The number of elements in the finite field.
-@return {bool} True if less than the field size.
-*/
-function hexLessThan(hexStr, fieldSize) {
-  const decStr = hexToDec(hexStr);
-  const q = new BI(fieldSize);
-  return new BI(decStr.toString()).lesserOrEquals(q);
-}
-
-/**
-@param {string} hexStr A hex string.
-@return {integer} The number of bits of information which are encoded by the hex value.
-*/
-function getBitLengthHex(hexStr) {
-  const decStr = hexToDec(hexStr);
-  return new BI(decStr).bitLength().toString();
-}
-
 // Converts binary value strings to hex values
 function binToHex(binStr) {
   const hex = convertBase(binStr, 2, 16);
   return hex ? `0x${hex}` : null;
 }
 
-/**
-@param {string} hexStr A hex string.
-@param {integer} n The number of bits to slice (from the right)
-@return {string} The right n bits of the hexStr.
-*/
-function sliceRightBitsHex(hexStr, n) {
-  let binStr = hexToBinSimple(hexStr);
-  binStr = binStr.slice(-n);
-  return binToHex(binStr);
-}
-
 // FUNCTIONS ON DECIMAL VALUES
-
-// Convert bits to decimal values between 0...255
-function decToBytes(decimal) {
-  const digit = parseInt(decimal, 2);
-  return digit;
-}
 
 // Converts decimal value strings to hex values
 function decToHex(decStr) {
@@ -364,14 +328,6 @@ function decToBin(decStr) {
   return convertBase(decStr, 10, 2);
 }
 
-/**
-@param {string} decStr A decimal value string.
-@return {integer} The number of bits of information which are encoded by the decimal value.
-*/
-function getBitLengthDec(decStr) {
-  return new BI(decStr).bitLength().toString();
-}
-
 /** Checks whether a decimal integer is larger than N bits, and splits its binary representation into chunks of size = N bits. The left-most (big endian) chunk will be the only chunk of size <= N bits. If the inequality is strict, it left-pads this left-most chunk with zeros.
 @param {string} decStr A decimal number/string.
 @param {integer} N The 'chunk size'.
@@ -382,16 +338,6 @@ function splitDecToBitsN(decStr, N) {
   let a = [];
   a = splitAndPadBitsN(bitStr, N);
   return a;
-}
-
-/** Preserves the magnitude of a decimal number in a finite field, even if the order of the field is smaller than decStr. decStr split into chunks of size packingSize. Relies on a sensible packing size being provided (ZoKrates uses packingSize = 128).
- */
-function decToFieldPreserve(decStr, packingSize) {
-  let bitsArr = [];
-  bitsArr = splitDecToBitsN(decStr.toString(), packingSize.toString());
-  let decArr = []; // decimal array
-  decArr = bitsArr.map(item => binToDec(item.toString()));
-  return decArr;
 }
 
 function isProbablyBinary(arr) {
@@ -426,18 +372,6 @@ function fieldsToDec(fieldsArr, packingSize) {
   return decStr;
 }
 
-/**
-Converts an array of Field Elements (decimal numbers which are smaller in magnitude than the field size q), where the array represents a number of magnitude larger than q, into the hex value which the array represents.
-@param {[string]} fieldsArr is an array of (decimal represented) field elements. Each element represents a number which is 2**128 times larger than the next in the array. So the 0th element of fieldsArr requires the largest left-shift (by a multiple of 2**128), and the last element is not shifted (shift = 1). The shifted elements should combine (sum) to the underlying decimal number which they represent.
-@param {integer} packingSize Each field element of fieldsArr is a 'packing' of exactly 'packingSize' bits. I.e. packingSize is the size (in bits) of each chunk (element) of fieldsArr. We use this to reconstruct the underlying decimal value which was, at some point previously, packed into a fieldsArr format.
-@returns {string} A hex value
-*/
-function fieldsToHex(fieldsArr, packingSize) {
-  const decStr = fieldsToDec(fieldsArr, packingSize).toString();
-  const hexStr = decToHex(decStr);
-  return ensure0x(hexStr);
-}
-
 // UTILITY FUNCTIONS:
 
 /**
@@ -457,16 +391,6 @@ function xor(a, b) {
 }
 
 /**
-Utility function to xor to multiple hex strings and return as string
-*/
-function xorItems(...items) {
-  const xorvalue = items
-    .map(item => Buffer.from(strip0x(item), 'hex'))
-    .reduce((acc, item) => xor(acc, item));
-  return `0x${xorvalue.toString('hex')}`;
-}
-
-/**
 Utility function to concatenate two hex strings and return as buffer
 Looks like the inputs are somehow being changed to decimal!
 */
@@ -480,16 +404,6 @@ function concatenate(a, b) {
     buffer[a.length + j] = b[j];
   }
   return buffer;
-}
-
-/**
-Utility function to concatenate multiple hex strings and return as string
-*/
-function concatenateItems(...items) {
-  const concatvalue = items
-    .map(item => Buffer.from(strip0x(item), 'hex'))
-    .reduce((acc, item) => concatenate(acc, item));
-  return `0x${concatvalue.toString('hex')}`;
 }
 
 /**
@@ -533,15 +447,6 @@ function concatenateThenHash(...items) {
     .update(concatvalue, 'hex')
     .digest('hex')}`;
   return h;
-}
-
-// CONVERSION TO FINITE FIELD ELEMENTS:
-
-function splitBinToBitsN(binStr, N) {
-  const bitStr = binStr.toString();
-  let a = [];
-  a = splitAndPadBitsN(bitStr, N);
-  return a;
 }
 
 /**
@@ -615,14 +520,6 @@ function padHex(A, l) {
   return ensure0x(strip0x(A).padStart(l / 4, '0'));
 }
 
-function String2Hex(tmp) {
-  let str = '';
-  for (let i = 0; i < tmp.length; i += 1) {
-    str += tmp[i].charCodeAt(0).toString(16);
-  }
-  return str;
-}
-
 module.exports = {
   isHex,
   utf8StringToHex,
@@ -635,29 +532,19 @@ module.exports = {
   hexToDec,
   hexToField,
   hexToFieldPreserve,
-  hexLessThan,
-  getBitLengthHex,
-  sliceRightBitsHex,
-  decToBytes,
   decToHex,
   decToBin,
-  getBitLengthDec,
-  decToFieldPreserve,
   binToDec,
   binToHex,
   isProbablyBinary,
   fieldsToDec,
-  fieldsToHex,
   xor,
-  xorItems,
   concatenate,
-  concatenateItems,
   hash,
   concatenateThenHash,
   add,
   parseToDigitsArray,
   convertBase,
-  splitBinToBitsN,
   splitDecToBitsN,
   splitHexToBitsN,
   splitAndPadBitsN,
@@ -667,5 +554,4 @@ module.exports = {
   flattenDeep,
   padHex,
   leftPadHex,
-  String2Hex,
 };

--- a/zkp/__tests__/utils.test.js
+++ b/zkp/__tests__/utils.test.js
@@ -32,10 +32,6 @@ describe('utils.js tests', () => {
       expect(['0', '1', '3', '2']).toEqual(utils.hexToFieldPreserve('0x1e', 2, 4)); // 0x1e = 30 = 11110 = [01, 11, 10] = [1,3,2]
     });
 
-    test('hexLessThan should check whether a hex value is less than a large field number (decimal)', () => {
-      expect(utils.hexLessThan(hex, '17408914224622445473')).toBe(true);
-    });
-
     test('isHex should correctly decide if a number is hex or not', () => {
       expect(
         utils.isHex('0x02a7ce1bffb62c13bff46da151f1639b764602d56c8d4839d6cf2e57825c86bd'),
@@ -48,10 +44,6 @@ describe('utils.js tests', () => {
       ).toBe(true);
       expect(utils.isHex('1234567890')).toBe(true);
     });
-
-    test('getBitLengthHex should return the length of the binary representation of a Hex number', () => {
-      expect(utils.getBitLengthHex(hex)).toEqual('64');
-    });
   });
 
   describe('Functions on Decimal Values', () => {
@@ -61,18 +53,6 @@ describe('utils.js tests', () => {
 
     test('decToBin should correctly convert a decimal to binary', () => {
       expect(bin).toEqual(utils.decToBin(dec));
-    });
-
-    test('decToBytes should correctly covert binary into decimal', () => {
-      expect(utils.decToBytes('1001')).toEqual(9);
-    });
-
-    test('getBitLengthDec should return the length of the binary representation of a Decimal', () => {
-      expect(utils.getBitLengthDec(dec)).toEqual('64');
-    });
-
-    test(`decToFieldPreserve should correctly convert dec into a 'blocks' of finite field elements, of specified bit size, in decimal representation`, () => {
-      expect(['1', '3', '2']).toEqual(utils.decToFieldPreserve(30, 2)); // 30 = 11110 = [01, 11, 10] = [1,3,2]
     });
   });
 
@@ -90,47 +70,9 @@ describe('utils.js tests', () => {
     test('fieldsToDec should correctly convert an array of packed field elements (packed according to a set packing size) into the original decimal value which they represent', () => {
       expect(utils.fieldsToDec(['1', '3', '2'], 2)).toEqual('30');
     }); // [1,3,2]=[01,11,10](when packed in blocks of 2 bits)=011110 = 30(dec) = 1e (hex)
-
-    test('fieldsToHex should correctly convert an array of packed field elements (packed according to a set packing size) into the original hex value which they represent', () => {
-      expect('0x1e').toEqual(utils.fieldsToHex(['1', '3', '2'], 2));
-    }); // [1,3,2]=[01,11,10](when packed in blocks of 2 bits)=011110 = 30(dec) = 1e (hex)
   });
 
   describe('Utility Functions', () => {
-    test('xorItems should correctly convert xor two hex strings', () => {
-      expect('0x156000000010000000000000000000000000000000000000000000000003b02e').toEqual(
-        utils.xorItems(
-          '0x56551cd11fffd4df21a9bdfc366d31bb8cdb4df7b155b9d97d66346c09823776',
-          '0x43351cd11fefd4df21a9bdfc366d31bb8cdb4df7b155b9d97d66346c09818758',
-        ),
-      );
-    });
-
-    test('concatenateItems should correctly concatenate two hex strings', () => {
-      expect(
-        '0x56551cd11fffd4df21a9bdfc366d31bb8cdb4df7b155b9d97d66346c0982377643351cd11fefd4df21a9bdfc366d31bb8cdb4df7b155b9d97d66346c09818758',
-      ).toEqual(
-        utils.concatenateItems(
-          '0x56551cd11fffd4df21a9bdfc366d31bb8cdb4df7b155b9d97d66346c09823776',
-          '0x43351cd11fefd4df21a9bdfc366d31bb8cdb4df7b155b9d97d66346c09818758',
-        ),
-      );
-    });
-
-    test('concatenateItems should correctly concatenate three hex strings', () => {
-      expect('0x0000000000002710a48eb90d402c7d1fcd8d31e3cc9af568').toEqual(
-        utils.concatenateItems('0x0000000000002710', '0xa48eb90d402c7d1f', '0xcd8d31e3cc9af568'),
-      );
-    });
-
-    test('concatenateItems should correctly concatenate three hex strings', () => {
-      expect('0xaabbcc').toEqual(utils.concatenateItems('0xaa', '0xbb', '0xcc'));
-    });
-
-    test('concatenateItems should correctly concatenate two hex strings', () => {
-      expect('0x10da').toEqual(utils.concatenateItems('0x10', '0xda'));
-    });
-
     test('utils.hash should correctly create a truncated sha256 hash of a concatentation of numbers', () => {
       const testInputHash = utils.hash('0x0000000000002710a48eb90d402c7d1fcd8d31e3cc9af568');
       const truncated = '0xb5a95142b8fa2cd63d51e6e7f6584186ce955be1c6bebc20d03f9148b8886fea';
@@ -146,36 +88,6 @@ describe('utils.js tests', () => {
       const truncated = 'b5a95142b8fa2cd63d51e6e7f6584186ce955be1c6bebc20d03f9148b8886fea';
       const calculatedHash = `0x${truncated.slice(truncated.length - testInputHash.length + 2)}`;
       expect(calculatedHash).toEqual(testInputHash);
-    });
-
-    test('splitBinToBitsN should split a binary string into chunks of size N bits (N=8 in this test)', () => {
-      expect([
-        '11110001',
-        '10011000',
-        '11100011',
-        '01000000',
-        '00111011',
-        '11011101',
-        '10100011',
-        '10100000',
-      ]).toEqual(
-        utils.splitBinToBitsN(
-          '1111000110011000111000110100000000111011110111011010001110100000',
-          8,
-        ),
-      );
-      expect([
-        '00110001',
-        '10011000',
-        '11100011',
-        '01000000',
-        '00111011',
-        '11011101',
-        '10100011',
-        '10100000',
-      ]).toEqual(
-        utils.splitBinToBitsN('11000110011000111000110100000000111011110111011010001110100000', 8),
-      );
     });
 
     test('splitDecToBitsN should split a decimal string into chunks of size N bits (N=8 in this test)', () => {


### PR DESCRIPTION
These functions aren't being used in the codebase currently. It's best practice to remove unused code to keep the codebase small. If we need these functions in the future, we can get them back through git.