### PR TITLE
Pull out provider into own folder for sdk prep

### DIFF
--- a/zkp/src/index.js
+++ b/zkp/src/index.js
@@ -5,9 +5,11 @@
 //
 import express from 'express';
 import bodyParser from 'body-parser';
+import config from 'config';
 import { ftCommitmentRoutes, ftRoutes, nftCommitmentRoutes, nftRoutes } from './routes';
 import vkController from './vk-controller';
 import { formatResponse, formatError, errorHandler } from './middlewares';
+import { setProvider } from './sdkProvider';
 
 const app = express();
 
@@ -66,6 +68,9 @@ app.use(function logError(err, req, res, next) {
 
 app.use(formatError);
 app.use(errorHandler);
+
+// Set provider for library functions.
+setProvider(config.get('web3ProviderURL'));
 
 const server = app.listen(80, '0.0.0.0', () =>
   console.log('Zero-Knowledge-Proof RESTful API server started on ::: 80'),

--- a/zkp/src/sdkProvider.js
+++ b/zkp/src/sdkProvider.js
@@ -1,0 +1,42 @@
+/*
+ * This is a temporary module for setting a provider for the library functions.
+ * We want Nightfall to be as stand-alone as possible.
+ * This module will eventually be pulled out into its own library.
+ */
+
+import contract from 'truffle-contract';
+import Web3 from 'web3';
+
+let provider = null;
+
+/**
+ * Sets the provider that will be used for the library functions
+ * @param {String} uri
+ */
+export function setProvider(uri) {
+  if (!uri) throw new Error('No uri was provided');
+  provider = new Web3.providers.WebsocketProvider(uri);
+}
+
+/**
+ * Get the instantiated provider
+ * @throws {Error} - if no provider is instantiated
+ * @returns {Web3.eth.WebsocketProvider}
+ */
+export function getProvider() {
+  if (!provider) throw new Error('No provider was set for sdk');
+  return provider;
+}
+
+/**
+ * Helper function to instantiate contracts given their JSON and address
+ * @param {Object} json
+ * @param {String} address
+ * @returns {truffle-contract.contract}
+ */
+export async function instantiateContract(json, address) {
+  const contractObject = contract(json);
+  contractObject.setProvider(getProvider());
+  const instance = await contractObject.at(address);
+  return instance;
+}

--- a/zkp/src/vk-controller.js
+++ b/zkp/src/vk-controller.js
@@ -12,6 +12,7 @@ import config from 'config';
 import utils from './zkpUtils';
 import Web3 from './web3';
 import { getContract } from './contractUtils';
+import { instantiateContract } from './sdkProvider';
 
 const web3 = Web3.connection();
 
@@ -36,13 +37,9 @@ async function loadVk(vkJsonFile, blockchainOptions) {
 
   console.log(`Loading VK for ${vkJsonFile}`);
 
-  const verifier = contract(verifierJson);
-  verifier.setProvider(Web3.connect());
-  const verifierInstance = await verifier.at(verifierAddress);
+  const verifier = await instantiateContract(verifierJson, verifierAddress);
 
-  const verifierRegistry = contract(verifierRegistryJson);
-  verifierRegistry.setProvider(Web3.connect());
-  const verifierRegistryInstance = await verifierRegistry.at(verifierRegistryAddress);
+  const verifierRegistry = await instantiateContract(verifierRegistryJson, verifierRegistryAddress);
 
   // Get VKs from the /code/gm17 directory and convert them into Solidity uints.
   let vk = await new Promise((resolve, reject) => {
@@ -57,7 +54,7 @@ async function loadVk(vkJsonFile, blockchainOptions) {
 
   // upload the vk to the smart contract
   console.log('Registering verifying key');
-  const txReceipt = await verifierRegistryInstance.registerVk(vk, [verifierInstance.address], {
+  const txReceipt = await verifierRegistry.registerVk(vk, [verifier.address], {
     from: account,
     gas: 6500000,
     gasPrice: config.GASPRICE,


### PR DESCRIPTION
Although this change seems redundant, having a separate provider manager for the functions that will eventually be pulled out for the SDK will make things go much more smoothly later on. That way we can pull out the `sdkProvider` with the rest of the functions and be more agnostic about what libraries we're using. 