### PR TITLE
(zkp-unit-test) load all vkIds at first

### DIFF
--- a/zkp/__tests__/loadVK.js
+++ b/zkp/__tests__/loadVK.js
@@ -1,7 +1,7 @@
 import bc from '../src/web3';
 import vk from '../src/vk-controller';
 
-(async function loadVkIds() {
+global.loadVkIds = async function loadVkIds() {
   if (!(await bc.isConnected())) return;
   await vk.runController();
-})();
+};

--- a/zkp/__tests__/test-environment.js
+++ b/zkp/__tests__/test-environment.js
@@ -1,6 +1,7 @@
 const NodeEnvironment = require('jest-environment-node');
 
 module.exports = class CustomEnvironment extends NodeEnvironment {
+  /* eslint-disable no-useless-constructor */
   constructor(config) {
     super(config);
   }
@@ -17,4 +18,4 @@ module.exports = class CustomEnvironment extends NodeEnvironment {
   runScript(script) {
     return super.runScript(script);
   }
-}
+};

--- a/zkp/__tests__/test-environment.js
+++ b/zkp/__tests__/test-environment.js
@@ -1,0 +1,20 @@
+const NodeEnvironment = require('jest-environment-node');
+
+module.exports = class CustomEnvironment extends NodeEnvironment {
+  constructor(config) {
+    super(config);
+  }
+
+  async setup() {
+    await super.setup();
+    await this.global.loadVkIds();
+  }
+
+  async teardown() {
+    await super.teardown();
+  }
+
+  runScript(script) {
+    return super.runScript(script);
+  }
+}

--- a/zkp/package.json
+++ b/zkp/package.json
@@ -48,6 +48,7 @@
     "nodemon": "^1.19.0"
   },
   "jest": {
+    "testEnvironment": "/app/__tests__/test-environment.js",
     "setupFilesAfterEnv": [
       "jest-expect-message"
     ],


### PR DESCRIPTION
# Description
This PR modify existing behaviour of asynchronously loading of vkIDs parallelly to test, to asynchronously loading of vkIDs sequentially to test.

## How Has This Been Tested
By run zkp unit test locally

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.