### PR TITLE
fix(github actions):  exit with error if integration test failed

### DIFF
--- a/nightfall-test
+++ b/nightfall-test
@@ -5,6 +5,8 @@ GREEN='\033[0;32m'
 RED='\033[0;31m'
 NC='\033[0m'
 
+declare isTestFailed=false
+
 printf "${GREEN}*** Cleaning up all test containers ***${NC}\n"
 docker-compose down -v || true
 
@@ -41,7 +43,7 @@ sleep 20
 
 # RUN test suits and remove test containers
 printf "${GREEN}*** Run Integration test ***${NC}\n"
-npm run test || printf "${RED}*** Integration test failed ***${NC}\n"
+npm run test || isTestFailed=true
 
 printf "${GREEN}*** List all containers with their Ips ***${NC}\n"
 docker inspect -f '{{.Name}} {{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $(docker-compose ps -q)
@@ -61,3 +63,9 @@ docker-compose down -v || {
   printf "${GREEN}*** Remove zkp-code volume ***${NC}\n"
   docker volume rm nightfall_zkp-code
 }
+
+if $isTestFailed
+then
+  printf "${RED}*** Integration test failed ***${NC}\n"
+  exit 1
+fi


### PR DESCRIPTION
# Description
Currently, ```./nightfall-test``` is not exiting with error, if integration test failed. This PR fixes that, so that github actions to check . integration test should fails
 
## How Has This Been Tested
By run integration test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.