### PR TITLE
Abort if existing trusted setup found

### DIFF
--- a/zkp/.dockerignore
+++ b/zkp/.dockerignore
@@ -96,5 +96,3 @@ typings/
 !**/*.pcode
 !**/aux-*code
 **/vkIds.json
-**/safe-dump/**
-!**/safe-dump/README.md

--- a/zkp/.gitignore
+++ b/zkp/.gitignore
@@ -102,5 +102,3 @@ src/vkIds.json
 # We want to keep ft-burn.code, but not out.code
 **/out.code
 **/vkIds.json
-**/safe-dump/**
-!**/safe-dump/README.md

--- a/zkp/code/README-trusted-setup.md
+++ b/zkp/code/README-trusted-setup.md
@@ -93,9 +93,6 @@ zkp
       ft-transfer
         |
         ft-transfer.code
-
-    safe-dump   // required folder, in case of accidental overwriting from mounting of containers from the host.
-      |
 ```
 
 Example to compile and generate a new (proving key, verification key) pair for a 'fungible token
@@ -134,9 +131,6 @@ zkp
       ft-transfer
         |
         ft-transfer.code
-
-    safe-dump
-      |
 ```
 
 ### Suppress Console Logs

--- a/zkp/code/index.js
+++ b/zkp/code/index.js
@@ -89,8 +89,9 @@ async function filingChecks(codeDirectory) {
     // Looking for a .code file, but not out.code
     if (files[j].endsWith('.code') && files[j] !== 'out.code') {
       codeFile = files[j];
+    } else {
+      return 1;
     }
-    else return 1;
   }
 
   await checkForImportFiles(`${codeDirectory}`, codeFile);

--- a/zkp/code/index.js
+++ b/zkp/code/index.js
@@ -89,7 +89,7 @@ async function filingChecks(codeDirectory) {
     // Looking for a .code file, but not out.code
     if (files[j].endsWith('.code') && files[j] !== 'out.code') {
       codeFile = files[j];
-    } 
+    }
     else return 1;
   }
 
@@ -182,7 +182,8 @@ async function runSetup(codeDirectory, suppress) {
   if (dirtyDir) {
     console.log('Existing trusted setup is already installed.');
     console.log('These are files other than *.code at: ', codeDirectory);
-    console.log('Nightfall will not overwrite existing trusted setup file. You must manually delete them if you wish to regerenate.');
+    console.log('Nightfall will not overwrite existing trusted setup file.');
+    console.log('You must manually delete them if you wish to regerenate.');
     console.error('\nSetup aborted due to existing trusted setup.');
     return;
   }
@@ -212,7 +213,8 @@ async function runSetupAll(codeDirectory, suppress) {
   if (dirtyDirs.length) {
     console.log('Existing trusted setup is already installed.');
     console.log('These are files other than *.code at: ', dirtyDirs);
-    console.log('Nightfall will not overwrite existing trusted setup files. You must manually delete them if you wish to regerenate.');
+    console.log('Nightfall will not overwrite existing trusted setup file.');
+    console.log('You must manually delete them if you wish to regerenate.');
     console.error('\nSetup aborted due to existing trusted setup.');
     return;
   }

--- a/zkp/code/safe-dump/README.md
+++ b/zkp/code/safe-dump/README.md
@@ -1,3 +1,0 @@
-This folder '.../code/safe-dump' exists as a backup of .pcode files when using
-index.js, in case mounting to docker containers results in accidentally overwriting or
-deleting original .code files from their original directories.


### PR DESCRIPTION
# Description

Abort if there was already a trusted setup found.

This removes the need for safe-dump.

## Related Issue

#303

## Motivation and Context

Increase safety. Removing an existing trusted setup is an advanced action. Currently this happens just by running `yes |` which is convenient for developers. The new behavior requires more explicit action from the end user to delete and existing trusted setup.

## How Has This Been Tested

CI

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Credits

Thank you to Damiano Shehaj for help with this issue.