### PR TITLE
trigger test-pull-request.yml github action on existing outdated PRs

### DIFF
--- a/.github/workflows/re-run-pull-request-github-actions.yml
+++ b/.github/workflows/re-run-pull-request-github-actions.yml
@@ -1,0 +1,71 @@
+name: Re-run Pull-Request's last github actions
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/workflows/*'
+      - 'integration-test/*'
+      - 'zkp/_tests_/*'
+
+jobs:
+  re-run-github-actions:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Hello world
+        run: echo Hello world $GITHUB_TOKEN
+        env:
+          GITHUB_TOKEN: ${{secrets.PAT}}
+      - name: (GET-&-PUT Github API) Push empty commit to PR branch
+        uses: actions/github-script@0.2.0
+        with:
+          github-token: ${{secrets.PAT}}
+          debug: true
+          script: |
+            const owner = context.payload.organization.login;
+            const repo = context.payload.repository.name;
+            const {data: pullRequests} = await github.pulls.list({
+              owner,
+              repo,
+              base: "master",
+              state: "open",
+            });
+          
+            for (pr of pullRequests) {
+
+              let pullReq = {};
+              while (pullReq.mergeable === undefined || pullReq.mergeable === null) {
+                pullReq = (
+                  await github.pulls.get({
+                    owner,
+                    repo,
+                    pull_number: pr.number,
+                  })
+                ).data;
+              }
+              if(pullReq.mergeable === false) continue;
+
+              const {data: commitData} = await github.repos.getCommit({
+                owner,
+                repo,
+                ref: pullReq.head.sha,
+              });
+
+              const {data: createdCommit} = await github.git.createCommit({
+                owner,
+                repo,
+                message: "tigger github actions",
+                tree: commitData.commit.tree.sha,
+                parents: [commitData.sha],
+                commiter: context.payload.pusher,
+                author: context.payload.pusher,
+              });
+
+              await github.git.updateRef({
+                owner,
+                repo,
+                ref: `heads/${pr.head.ref}`,
+                sha: createdCommit.sha,
+              });
+            }

--- a/.github/workflows/re-run-pull-request-github-actions.yml
+++ b/.github/workflows/re-run-pull-request-github-actions.yml
@@ -21,7 +21,6 @@ jobs:
         uses: actions/github-script@0.2.0
         with:
           github-token: ${{secrets.PAT}}
-          debug: true
           script: |
             const owner = context.payload.organization.login;
             const repo = context.payload.repository.name;


### PR DESCRIPTION

# Description
This PR add new github workflow file ```re-run-pull-request-github-actions.yml``` which will trigger when a PR is merged to master, and workflow will also push an empty commit to existing PR to trigger ```test-pull-request.yml``` PR test github action workflow

## Motivation and Context
Outdated PRs check were wrongly consider to successful ran against frequently updating master branch  

## How Has This Been Tested
code has been test in temporary branch ```liju.jose/configure-github-actions-4``` and test for PR #297 by logically creating an empty commit #eed99c238e778d930db7241f3d853afcaa8dcad9 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.