### PR TITLE
fix: Race condition - checking correctness of received commitment

### DIFF
--- a/api-gateway/src/services/nft-commitment.js
+++ b/api-gateway/src/services/nft-commitment.js
@@ -214,6 +214,7 @@ export async function transferToken(req, res, next) {
       salt: data.S_B,
       commitment: data.z_B,
       commitmentIndex: parseInt(data.z_B_index, 16),
+      blockNumber: data.txReceipt.receipt.blockNumber,
       receiver: req.body.receiver_name,
       receiverPublicKey: req.body.pk_B,
       for: 'NFTCommitment',
@@ -254,7 +255,7 @@ export async function burnToken(req, res, next) {
     // Release the public token from escrow:
     // Nullify the burnor's 'token commitment' within the shield contract.
     // Transfer the public token from the shield contract to the owner.
-    await zkp.burnToken(req.user, {
+    res.data = await zkp.burnToken(req.user, {
       tokenId: req.body.A,
       salt: req.body.S_A,
       secretKey: user.secretkey,
@@ -282,6 +283,7 @@ export async function burnToken(req, res, next) {
         receiver: req.body.payTo, // this will change when payTo will be a user other than burner himself.
         sender: req.user.name,
         senderAddress: req.user.address,
+        blockNumber: res.data.txReceipt.receipt.blockNumber,
         for: 'NFTToken',
       });
     } else {

--- a/offchain/src/listeners.js
+++ b/offchain/src/listeners.js
@@ -36,18 +36,36 @@ async function insertFTTransactionToDb(data, userData) {
 }
 
 async function insertNFTCommitmentToDb(data, userData) {
-  console.log('\noffchain/src/listeners.js', '\naddToken', '\ndata', data, '\nuserData', userData);
+  console.log(
+    '\noffchain/src/listeners.js',
+    '\ninsertNFTCommitmentToDb',
+    '\ndata',
+    data,
+    '\nuserData',
+    userData,
+  );
+
+  const {
+    tokenUri,
+    tokenId,
+    salt,
+    receiverPublicKey,
+    commitment,
+    commitmentIndex,
+    blockNumber,
+  } = data;
 
   const correctnessChecks = await apiGateway.checkCorrectnessForNFTCommitment(
     {
       authorization: userData.jwtToken,
     },
     {
-      A: data.tokenId,
-      pk: data.receiverPublicKey,
-      S_A: data.salt,
-      z_A: data.commitment,
-      z_A_index: data.commitmentIndex,
+      tokenId,
+      receiverPublicKey,
+      salt,
+      commitment,
+      commitmentIndex,
+      blockNumber,
     },
   );
 
@@ -63,14 +81,14 @@ async function insertNFTCommitmentToDb(data, userData) {
       authorization: userData.jwtToken,
     },
     {
-      tokenUri: data.tokenUri,
-      tokenId: data.tokenId,
-      salt: data.salt,
-      commitment: data.commitment,
-      commitmentIndex: data.commitmentIndex,
+      tokenUri,
+      tokenId,
+      salt,
+      commitment,
+      commitmentIndex,
       isReceived: true,
-      zCorrect: correctnessChecks.data.z_correct,
-      zOnchainCorrect: correctnessChecks.data.z_onchain_correct,
+      zCorrect: correctnessChecks.data.zCorrect,
+      zOnchainCorrect: correctnessChecks.data.zOnchainCorrect,
     },
   );
 }
@@ -85,16 +103,19 @@ async function insertFTCommitmentToDb(data, userData) {
     userData,
   );
 
+  const { amount, salt, pk, commitment, commitmentIndex, blockNumber } = data;
+
   const correctnessChecks = await apiGateway.checkCorrectnessForFTCommitment(
     {
       authorization: userData.jwtToken,
     },
     {
-      E: data.amount,
-      S_E: data.salt,
-      pk: data.pk,
-      z_E: data.commitment,
-      z_E_index: data.commitmentIndex,
+      amount,
+      salt,
+      pk,
+      commitment,
+      commitmentIndex,
+      blockNumber,
     },
   );
 

--- a/zkp/__tests__/nf-token-controller.test.js
+++ b/zkp/__tests__/nf-token-controller.test.js
@@ -175,7 +175,7 @@ describe('nf-token-controller.js tests', () => {
   });
 
   test('Should burn the ERC 721 commitment for Bob for asset Z_B_A to return A ERC-721 Token', async () => {
-    const commitment = await controller.burn(
+    await controller.burn(
       A,
       skB,
       sAToBA,
@@ -194,7 +194,6 @@ describe('nf-token-controller.js tests', () => {
         pkPath: `${process.cwd()}/code/gm17/nft-burn/proving.key`,
       },
     );
-    expect(Z_B_A).toEqual(commitment);
     expect((await controller.getOwner(A, '')).toLowerCase()).toEqual(accounts[2].toLowerCase());
   });
 });

--- a/zkp/src/f-token-controller.js
+++ b/zkp/src/f-token-controller.js
@@ -666,7 +666,7 @@ there's no concept of joining and splitting (yet).
 @param {string} account - the account that is paying for this
 @returns {array} zE - The output token commitments
 @returns {array} z_E_index - the indexes of the commitments within the Merkle Tree.  This is required for later transfers/joins so that Alice knows which leaf of the Merkle Tree she needs to get from the fTokenShieldInstance contract in order to calculate a path.
-@returns {object} txObj - a promise of a blockchain transaction
+@returns {object} txReceipt - a promise of a blockchain transaction
 */
 async function simpleFungibleBatchTransfer(
   _inputCommitment,
@@ -1005,10 +1005,19 @@ async function burn(
 
   console.log('BURN COMPLETE\n');
   console.groupEnd();
-  return { z_C: commitment, z_C_index: commitmentIndex };
+
+  return { z_C: commitment, z_C_index: commitmentIndex, txReceipt };
 }
 
-async function checkCorrectness(amount, publicKey, salt, commitment, commitmentIndex, account) {
+async function checkCorrectness(
+  amount,
+  publicKey,
+  salt,
+  commitment,
+  commitmentIndex,
+  blockNumber,
+  account,
+) {
   const fTokenShieldInstance = shield[account] ? shield[account] : await FTokenShield.deployed();
 
   const results = await zkp.checkCorrectness(
@@ -1017,6 +1026,7 @@ async function checkCorrectness(amount, publicKey, salt, commitment, commitmentI
     salt,
     commitment,
     commitmentIndex,
+    blockNumber,
     fTokenShieldInstance,
   );
   console.log('\nf-token-controller', '\ncheckCorrectness', '\nresults', results);

--- a/zkp/src/f-token-zkp.js
+++ b/zkp/src/f-token-zkp.js
@@ -13,7 +13,15 @@ import merkleTree from './rest/merkle-tree';
 /**
 checks the details of an incoming (newly transferred token), to ensure the data we have received is correct and legitimate!!
 */
-async function checkCorrectness(value, publicKey, salt, commitment, commitmentIndex, fTokenShield) {
+async function checkCorrectness(
+  value,
+  publicKey,
+  salt,
+  commitment,
+  commitmentIndex,
+  blockNumber,
+  fTokenShield,
+) {
   console.log('Checking h(A|pk|S) = z...');
   const commitmentCheck = utils.concatenateThenHash(value, publicKey, salt);
   const zCorrect = commitmentCheck === commitment;
@@ -26,6 +34,10 @@ async function checkCorrectness(value, publicKey, salt, commitment, commitmentIn
   console.log('commitment:', commitment);
   console.log('commitmentIndex:', commitmentIndex);
   const { contractName } = fTokenShield.constructor._json; // eslint-disable-line no-underscore-dangle
+
+  // query the merkle-tree microservice until it's filtered the blockNumber we wish to query:
+  await merkleTree.waitForBlockNumber(contractName, blockNumber);
+
   const leaf = await merkleTree.getLeafByLeafIndex(contractName, commitmentIndex);
   console.log('leaf found:', leaf);
   if (leaf.value !== commitment)

--- a/zkp/src/nf-token-controller.js
+++ b/zkp/src/nf-token-controller.js
@@ -360,7 +360,7 @@ async function mint(tokenId, ownerPublicKey, salt, vkId, blockchainOptions, zokr
  * @param {String} blockchainOptions.account - Account that is sending these transactions
  * @returns {String} outputCommitment - New commitment
  * @returns {Number} outputCommitmentIndex - the index of the token within the Merkle Tree.  This is required for later transfers/joins so that Alice knows which 'chunks' of the Merkle Tree she needs to 'get' from the NFTokenShield contract in order to calculate a path.
- * @returns {Object} txObj - a promise of a blockchain transaction
+ * @returns {Object} txReceipt - a promise of a blockchain transaction
  */
 async function transfer(
   tokenId,
@@ -701,10 +701,18 @@ async function burn(
 
   console.log('BURN COMPLETE\n');
   console.groupEnd();
-  return commitment;
+  return { txReceipt };
 }
 
-async function checkCorrectness(tokenId, publicKey, salt, commitment, commitmentIndex, account) {
+async function checkCorrectness(
+  tokenId,
+  publicKey,
+  salt,
+  commitment,
+  commitmentIndex,
+  blockNumber,
+  account,
+) {
   const nfTokenShield = shield[account] ? shield[account] : await NFTokenShield.deployed();
 
   const results = await zkp.checkCorrectness(
@@ -713,6 +721,7 @@ async function checkCorrectness(tokenId, publicKey, salt, commitment, commitment
     salt,
     commitment,
     commitmentIndex,
+    blockNumber,
     nfTokenShield,
   );
   console.log('\nnf-token-controller', '\ncheckCorrectness', '\nresults', results);

--- a/zkp/src/nf-token-zkp.js
+++ b/zkp/src/nf-token-zkp.js
@@ -20,6 +20,7 @@ async function checkCorrectness(
   salt,
   commitment,
   commitmentIndex,
+  blockNumber,
   nfTokenShield,
 ) {
   console.log('Checking h(A|pk|S) = z...');
@@ -28,7 +29,7 @@ async function checkCorrectness(
     publicKey,
     salt,
   );
-  const z_correct = commitmentCheck === commitment; // eslint-disable-line camelcase
+  const zCorrect = commitmentCheck === commitment; // eslint-disable-line camelcase
   console.log('commitment:', commitment);
   console.log('commitmentCheck:', commitmentCheck);
 
@@ -38,6 +39,10 @@ async function checkCorrectness(
   console.log('commitment:', commitment);
   console.log('commitmentIndex:', commitmentIndex);
   const { contractName } = nfTokenShield.constructor._json; // eslint-disable-line no-underscore-dangle
+
+  // query the merkle-tree microservice until it's filtered the blockNumber we wish to query:
+  await merkleTree.waitForBlockNumber(contractName, blockNumber);
+
   const leaf = await merkleTree.getLeafByLeafIndex(contractName, commitmentIndex);
   console.log('leaf found:', leaf);
   if (leaf.value !== commitment)
@@ -45,13 +50,13 @@ async function checkCorrectness(
       `Could not find commitment ${commitment} at the given commitmentIndex ${commitmentIndex} in  the merkle-tree microservice. Found ${leaf.value} instead.`,
     );
 
-  const z_onchain_correct = leaf.value === commitment; // eslint-disable-line camelcase
+  const zOnchainCorrect = leaf.value === commitment; // eslint-disable-line camelcase
   console.log('commitment:', commitment);
   console.log('commitment emmitted by blockchain:', leaf.value);
 
   return {
-    z_correct,
-    z_onchain_correct,
+    zCorrect,
+    zOnchainCorrect,
   };
 }
 

--- a/zkp/src/routes/ft-commitment.js
+++ b/zkp/src/routes/ft-commitment.js
@@ -96,7 +96,7 @@ async function transfer(req, res, next) {
   try {
     const {
       outputCommitments: returnedOutputCommitments,
-      transferReceipt,
+      txReceipt,
     } = await fTokenController.transfer(
       inputCommitments,
       outputCommitments,
@@ -121,7 +121,7 @@ async function transfer(req, res, next) {
       z_F_index: returnedOutputCommitments[1].index,
       S_E: returnedOutputCommitments[0].salt,
       S_F: returnedOutputCommitments[1].salt,
-      txObj: transferReceipt,
+      txReceipt,
     };
     next();
   } catch (err) {
@@ -139,7 +139,7 @@ async function burn(req, res, next) {
   } = await getTruffleContractInstance('FTokenShield');
 
   try {
-    await fTokenController.burn(
+    const { txReceipt } = await fTokenController.burn(
       amount,
       receiverSecretKey,
       salt,
@@ -161,6 +161,7 @@ async function burn(req, res, next) {
     res.data = {
       z_C: commitment,
       z_C_index: commitmentIndex,
+      txReceipt,
     };
     next();
   } catch (err) {
@@ -169,28 +170,21 @@ async function burn(req, res, next) {
 }
 
 async function checkCorrectness(req, res, next) {
-  console.log('\nzkp/src/restapi', '\n/checkCorrectnessForFTCommitment', '\nreq.body', req.body);
+  console.log('\nzkp/src/routes/ft-commitment', '\n/checkCorrectness', '\nreq.body', req.body);
 
   try {
     const { address } = req.headers;
-    const {
-      E: value,
-      pk: publicKey,
-      S_E: salt,
-      z_E: commitment,
-      z_E_index: commitmentIndex,
-    } = req.body;
+    const { amount, salt, pk, commitment, commitmentIndex, blockNumber } = req.body;
 
     const results = await fTokenController.checkCorrectness(
-      value,
-      publicKey,
+      amount,
+      pk,
       salt,
       commitment,
       commitmentIndex,
+      blockNumber,
       address,
     );
-    console.log('\nzkp/src/restapi', '\n/coin/checkCorrectness', '\nresults', results);
-
     res.data = results;
     next();
   } catch (err) {
@@ -206,7 +200,7 @@ async function setFTCommitmentShieldAddress(req, res, next) {
     await fTokenController.setShield(coinShield, address);
     await fTokenController.getBalance(address);
     res.data = {
-      message: 'CoinShield Address Set.',
+      message: 'FTokenShield Address Set.',
     };
     next();
   } catch (err) {
@@ -269,7 +263,7 @@ async function simpleFTCommitmentBatchTransfer(req, res, next) {
   }
 
   try {
-    const { z_E, z_E_index } = await fTokenController.simpleFungibleBatchTransfer(
+    const { z_E, z_E_index, txReceipt } = await fTokenController.simpleFungibleBatchTransfer(
       { value: amount, salt, commitment, index: commitmentIndex },
       transferData,
       receiversPublicKeys,
@@ -288,13 +282,18 @@ async function simpleFTCommitmentBatchTransfer(req, res, next) {
     );
 
     let lastCommitmentIndex = parseInt(z_E_index, 10);
+
     z_E.forEach((transferCommitment, indx) => {
       transferData[indx].commitment = transferCommitment;
       transferData[indx].commitmentIndex = lastCommitmentIndex - (z_E.length - 1);
       lastCommitmentIndex += 1;
     });
+    const commitments = transferData;
 
-    res.data = transferData;
+    res.data = {
+      commitments,
+      txReceipt,
+    };
     next();
   } catch (err) {
     next(err);

--- a/zkp/src/routes/nft-commitment.js
+++ b/zkp/src/routes/nft-commitment.js
@@ -64,11 +64,7 @@ async function transfer(req, res, next) {
   } = await getTruffleContractInstance('NFTokenShield');
 
   try {
-    const {
-      outputCommitment,
-      outputCommitmentIndex,
-      transferReceipt,
-    } = await nfController.transfer(
+    const { outputCommitment, outputCommitmentIndex, txReceipt } = await nfController.transfer(
       tokenId,
       receiverPublicKey,
       originalCommitmentSalt,
@@ -91,8 +87,8 @@ async function transfer(req, res, next) {
     res.data = {
       z_B: outputCommitment,
       z_B_index: outputCommitmentIndex,
-      txObj: transferReceipt,
       S_B: newCommitmentSalt,
+      txReceipt,
     };
     next();
   } catch (err) {
@@ -110,7 +106,7 @@ async function burn(req, res, next) {
   } = await getTruffleContractInstance('NFTokenShield');
 
   try {
-    await nfController.burn(
+    const { txReceipt } = await nfController.burn(
       tokenId,
       secretKey,
       salt,
@@ -131,6 +127,7 @@ async function burn(req, res, next) {
     );
     res.data = {
       z_A: commitment,
+      txReceipt,
     };
     next();
   } catch (err) {
@@ -139,17 +136,11 @@ async function burn(req, res, next) {
 }
 
 async function checkCorrectness(req, res, next) {
-  console.log('\nzkp/src/restapi', '\n/checkCorrectnessForNFTCommitment', '\nreq.body', req.body);
+  console.log('\nzkp/src/routes/nft-commitment', '\n/checkCorrectness', '\nreq.body', req.body);
 
   try {
     const { address } = req.headers;
-    const {
-      A: tokenId,
-      pk: ownerPublicKey,
-      S_A: salt,
-      z_A: commitment,
-      z_A_index: commitmentIndex,
-    } = req.body;
+    const { tokenId, ownerPublicKey, salt, commitment, commitmentIndex, blockNumber } = req.body;
 
     const results = await nfController.checkCorrectness(
       tokenId,
@@ -157,6 +148,7 @@ async function checkCorrectness(req, res, next) {
       salt,
       commitment,
       commitmentIndex,
+      blockNumber,
       address,
     );
     res.data = results;
@@ -174,7 +166,7 @@ async function setNFTCommitmentShieldAddress(req, res, next) {
     await nfController.setShield(tokenShield, address);
     await nfController.getNFTName(address);
     res.data = {
-      message: 'TokenShield Address Set.',
+      message: 'NFTokenShield Address Set.',
     };
     next();
   } catch (err) {


### PR DESCRIPTION
# Description

<!--- Describe your changes in detail -->

The `blockNumber` of a transfer & burn is now shared from Alice to Bob. Bob can then poll his merkle-tree db until is has filtered this block. He can then query whether his new commitment does indeed exist within the Merkle Tree at the specified index.

## Related Issue

fixes #330 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Fixes a race condition bug, where Bob was querying his db before the event filter had necessarily picked up the tx.

## How Has This Been Tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Integration test & unit tests & manual UI tests transferring / burning from Alice to Bob and checking Bob's 'transaction history' pages correctly 'pick up' the required info.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.