### PR TITLE
trusted setup now ignores common folder

### DIFF
--- a/nightfall-generate-trusted-setup
+++ b/nightfall-generate-trusted-setup
@@ -12,11 +12,11 @@ completedSetupList=""
 selectedSetupsIndexes=""
 declare -i index=0
 
-# Get available trusted setup names
+# Get available trusted setup names, excluding the 'common' directory
 pushd zkp/code/gm17/
 for d in *
 do
-  if [ -d "$d" ]
+  if [ -d "$d" ] && [ "$d" != "common" ]
   then
     index+=1
     setupList+="${index} $d\n"


### PR DESCRIPTION
# Description

<!--- Describe your changes in detail -->
We have quite a bit of identical code in our proofs (ZoKrates dsl).  This could easily be refactored into a common directory.  Unfortunately the trusted setup would attempt to build any such code, which would fail as it would not intended to be compiled as a stand-alone proof.  To fix that, I've altered the `./nightfall-generate-trusted-setup` script to ignore a directory named 'common'.  This gives us a place to store functions common to multiple proofs.

## Related Issue

Fixes #344

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested
Tested by running `./nightfall-generate-trusted-setup` script and checking manually for correct operation (code in `common` folder is ignored)

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.