### PR TITLE
Revert "Use docker image for timber"

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -28,8 +28,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '10.15.3'
-      - name: login to github registry
-        run: docker login -u ${{ secrets.GITHUB_USERNAME }} -p ${{ secrets.GITHUB_PASSWORD }} docker.pkg.github.com
       - name: Pull docker image
         run: docker pull zokrates/zokrates:0.5.1
       - name: Increase swap memory
@@ -51,12 +49,11 @@ jobs:
           docker rm $(docker ps -a -q)
       - name: Build zkp image
         run: docker-compose build zkp
-      - name: Setup ganache container, deploy zkp contracts
+      - name: Setup ganache container, deploy zkp contracts and start the merkle-tree microservice
         run: |
           docker-compose run --rm truffle-zkp compile --all
           docker-compose run --rm truffle-zkp migrate --reset --network=default
-      - name: Start merkle-tree microservice
-        run: docker-compose up -d merkle-tree
+          docker-compose -f docker-compose.merkle-tree.yml up -d --build
       - name: Run zkp unit tests
         run: docker-compose run --rm zkp npm test
 
@@ -70,8 +67,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: '10.15.3'
-      - name: login to github registry
-        run: docker login -u ${{ secrets.GITHUB_USERNAME }} -p ${{ secrets.GITHUB_PASSWORD }} docker.pkg.github.com
       - name: Pull docker image
         run: docker pull zokrates/zokrates:0.5.1
       - name: Increase swap memory

--- a/README.md
+++ b/README.md
@@ -54,12 +54,14 @@ Start Docker:
 Clone the Nightfall repository:
 
 ```sh
-git clone git@github.com:EYBlockchain/nightfall.git
+git clone --recurse-submodules git@github.com:EYBlockchain/nightfall.git
 ```
 or:
 ```sh
-git clone https://github.com/EYBlockchain/nightfall.git
+git clone --recurse-submodules https://github.com/EYBlockchain/nightfall.git
 ```
+
+_(Notice this repository contains git submodules. See [submodules.md](./submodules.md) for more commands relating to cloning, pulling, pushing, and branching this codebase.)_
 
 Enter the directory:  
 
@@ -106,10 +108,10 @@ You just created all the files needed to generate zk-SNARKs. The proving keys, v
 
 #### Re-installation
 
-If this isn't your first time running Nightfall, but you have just pulled new changes from the repo, then you might need to 're-install' certain features due to code changes. First run:  
+If this isn't your first time running Nightfall, but you have just [pulled](./submodules.md) new changes from the repo, then you might need to 're-install' certain features due to code changes. First run:  
 
 ```sh
-docker-compose -f docker-compose.yml build
+docker-compose -f docker-compose.merkle-tree.yml -f docker-compose.yml build
 ```
 
 It's important to re-run the trusted setup if any of the `.code` files have been modified since your last pull of the repo. You can check with:  
@@ -149,7 +151,7 @@ Note that it can take up to 10 mins to compute a transfer proof (depending on yo
 If you want to close the application, make sure to stop containers and remove containers, networks, volumes, and images created by up, using:
 
 ```sh
-docker-compose down -v
+docker-compose -f docker-compose.merkle-tree.yml -f docker-compose.yml down -v
 ```
 
 ### To run zkp service unit tests

--- a/docker-compose.merkle-tree.yml
+++ b/docker-compose.merkle-tree.yml
@@ -1,0 +1,52 @@
+version: '3.5'
+
+services:
+  # The main microservice for reconstructing a merkle tree
+  merkle-tree:
+    build:
+      context: ./merkle-tree/merkle-tree
+      dockerfile: Dockerfile
+    restart: on-failure
+    depends_on:
+      - mongo-merkle-tree
+    volumes:
+      - ./merkle-tree/merkle-tree/src:/app/src
+      - ./config/merkle-tree:/app/config # mount point might be different if configuring from another application
+      - ./merkle-tree/merkle-tree/test:/app/test
+      - ./merkle-tree/merkle-tree/.babelrc:/app/.babelrc
+      - ./merkle-tree/merkle-tree/setup-mongo-acl-for-new-users.js:/app/setup-mongo-acl-for-new-users.js
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./zkp/contracts/:/app/contracts:consistent # required if deploying contracts from within this service (if CONTRACT_LOCATION = 'default')
+      - ./zkp/build/:/app/build:consistent # required if CONTRACT_LOCATION = 'default'
+    ports:
+      - "9000:80"
+    environment:
+      BLOCKCHAIN_HOST: ws://ganache
+      BLOCKCHAIN_PORT: 8545
+      CONTRACT_LOCATION: 'default' # Where to find the contractInstances?
+      # Specify one of:
+      # - 'remote' (to GET them from a remote microservice); or
+      # - 'mongodb' (to get them from mongodb); or
+      # - 'default' (to get them from the app/build/ folder)
+    networks:
+      - merkle_tree_network
+
+  # The database storing the merkle tree
+  mongo-merkle-tree:
+    image: mongo
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=admin
+      - MONGO_INITDB_ROOT_PASSWORD=admin
+      - MONGO_INITDB_DATABASE=merkle_tree
+    volumes:
+      - ./merkle-tree/merkle-tree/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+      - mongo-merkle-tree-volume:/data/db
+    networks:
+      - merkle_tree_network
+
+volumes:
+  mongo-merkle-tree-volume: {}
+
+networks:
+  merkle_tree_network:
+    name: merkle_tree_network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,7 @@ services:
       NIGHTLITE_LOG_LEVEL: debug
     networks:
       - nightfall_network
+      - merkle_tree_network
 
   ui:
     build:
@@ -114,6 +115,7 @@ services:
       - '8545:8545'
     networks:
       - nightfall_network
+      - merkle_tree_network
 
   database:
     build:
@@ -184,51 +186,8 @@ services:
     networks:
       - nightfall_network
 
-  merkle-tree:
-    image:
-      docker.pkg.github.com/eyblockchain/timber/timber:v1.3.0
-    restart: on-failure
-    depends_on:
-      - mongo-merkle-tree
-      - ganache
-    volumes:
-      - ./config/merkle-tree:/app/config # mount point might be different if configuring from another application
-      - ./zkp/contracts/:/app/contracts:consistent # required if deploying contracts from within this service (if CONTRACT_LOCATION = 'default')
-      - ./zkp/build/:/app/build:consistent # required if CONTRACT_LOCATION = 'default'
-    ports:
-      - "9000:80"
-    environment:
-      BLOCKCHAIN_HOST: ws://ganache
-      BLOCKCHAIN_PORT: 8545
-      CONTRACT_LOCATION: 'default' # Where to find the contractInstances?
-      # Specify one of:
-      # - 'remote' (to GET them from a remote microservice); or
-      # - 'mongodb' (to get them from mongodb); or
-      # - 'default' (to get them from the app/build/ folder)
-      MONGO_HOST: mongodb://mongo-merkle-tree
-      MONGO_PORT: 27017
-      MONGO_NAME: merkle_tree
-      MONGO_USERNAME: admin
-      MONGO_PASSWORD: admin
-    networks:
-      - nightfall_network 
-
-  # The database storing the merkle tree
-  mongo-merkle-tree:
-    image: mongo
-    environment:
-      - MONGO_INITDB_ROOT_USERNAME=admin
-      - MONGO_INITDB_ROOT_PASSWORD=admin
-      - MONGO_INITDB_DATABASE=merkle_tree
-    volumes:
-      - ./docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
-      - mongo-merkle-tree-volume:/data/db
-    networks:
-      - nightfall_network
-
 volumes:
   mongo-nightfall-volume: {}
-  mongo-merkle-tree-volume: {}
   zkp-code-volume:
     driver: local
     driver_opts:
@@ -239,3 +198,5 @@ volumes:
 networks:
   nightfall_network:
     name: nightfall_network
+  merkle_tree_network:
+    name: merkle_tree_network

--- a/docker-entrypoint-initdb.d/01_setup_admin_user.js
+++ b/docker-entrypoint-initdb.d/01_setup_admin_user.js
@@ -1,9 +1,0 @@
-this.db.createUser({
-  user: 'admin',
-  pwd: 'admin',
-  roles: [
-    { role: 'userAdmin', db: 'merkle_tree' },
-    { role: 'dbAdmin', db: 'merkle_tree' },
-    { role: 'readWrite', db: 'merkle_tree' },
-  ],
-});

--- a/nightfall
+++ b/nightfall
@@ -6,7 +6,7 @@ RED='\033[0;31m'
 NC='\033[0m'
 
 printf "${GREEN}*** Cleaning up all containers ***${NC}\n"
-docker-compose -f docker-compose.yml down -v || {
+docker-compose -f docker-compose.merkle-tree.yml -f docker-compose.yml down -v || {
 	# this block will run if ```docker-compose down -v``` fails.
 	sleep 3
 
@@ -42,4 +42,4 @@ docker-compose run --rm truffle-offchain migrate --reset --network=default
 docker-compose run --rm truffle-zkp migrate --reset --network=default
 
 printf "${GREEN}*** Launching containerized microservices ***${NC}\n"
-docker-compose -f docker-compose.yml up --build
+docker-compose -f docker-compose.merkle-tree.yml -f docker-compose.yml up --build

--- a/nightfall-test
+++ b/nightfall-test
@@ -8,10 +8,10 @@ NC='\033[0m'
 declare isTestFailed=false
 
 printf "${GREEN}*** Cleaning up all test containers ***${NC}\n"
-docker-compose -f docker-compose.yml down -v || true
+docker-compose -f docker-compose.merkle-tree.yml -f docker-compose.yml down -v || true
 
 printf "${GREEN}*** Build image for all Containers ***${NC}\n"
-docker-compose -f docker-compose.yml build
+docker-compose -f docker-compose.merkle-tree.yml -f docker-compose.yml build
 
 printf "${GREEN}*** Pull zokrates docker image ***${NC}\n"
 docker pull zokrates/zokrates:0.5.1
@@ -32,11 +32,11 @@ docker-compose run --rm truffle-offchain migrate --reset --network=default
 docker-compose run --rm truffle-zkp migrate --reset --network=default
 
 printf "${GREEN}*** Launching containerized microservices ***${NC}\n"
-docker-compose -f docker-compose.yml up --build -d mongo-nightfall accounts offchain zkp database api-gateway mongo-merkle-tree merkle-tree
+docker-compose -f docker-compose.merkle-tree.yml -f docker-compose.yml up --build -d mongo-nightfall accounts offchain zkp database api-gateway mongo-merkle-tree merkle-tree
 
 # save all test logs to a file in background
 printf "${GREEN}*** Saving the test logs to nightfall_test.log file ***${NC}\n"
-docker-compose -f docker-compose.yml logs -f &> nightfall_test.log &disown
+docker-compose -f docker-compose.merkle-tree.yml -f docker-compose.yml logs -f &> nightfall_test.log &disown
 
 # delay needed to ensure all container are in running state.
 sleep 20
@@ -46,10 +46,10 @@ printf "${GREEN}*** Run Integration test ***${NC}\n"
 npm run test || isTestFailed=true
 
 printf "${GREEN}*** List all containers with their Ips ***${NC}\n"
-docker inspect -f '{{.Name}} {{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $(docker-compose -f docker-compose.yml ps -q)
+docker inspect -f '{{.Name}} {{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $(docker-compose -f docker-compose.merkle-tree.yml -f docker-compose.yml ps -q)
 
 printf "${GREEN}*** Cleaning up all containers ***${NC}\n"
-docker-compose -f docker-compose.yml down -v || {
+docker-compose -f docker-compose.merkle-tree.yml -f docker-compose.yml down -v || {
   # delay need as waiting time so all container are properly done
   # nightfall_default network have no dependency left.
   sleep 3
@@ -62,6 +62,9 @@ docker-compose -f docker-compose.yml down -v || {
 
   printf "${GREEN}*** Remove zkp-code volume ***${NC}\n"
   docker volume rm nightfall_zkp-code-volume
+
+	printf "${GREEN}*** Remove merkle_tree network ***${NC}\n"
+  docker network rm merkle_tree_network
 
 	printf "${GREEN}*** Remove the merkle tree's mongo volume ***${NC}\n"
   docker volume rm nightfall_mongo-merkle-tree-volume

--- a/submodules.md
+++ b/submodules.md
@@ -1,0 +1,32 @@
+# git submodules
+
+## cloning
+
+`git clone --recurse-submodules git@github.com:EYBlockchain/nightfall.git`
+
+## pulling
+
+`git pull --recurse-submodules`
+
+_If you didn't initially clone with the `--recurse-submodules` flag, you might need to `init` the git submodules first:_
+`git pull`  
+`git submodule update --init --recursive`  
+_This will pull the submodules' code into your repo for the first time (as subfolders). Thereafter the `git pull --recurse-submodules` command will pull changes._
+
+## pushing
+
+`git push --recurse-submodules=check` checks for any changes you might have made in the submodule, and stops you pushing to Nightfall without first pushing to the submodule's remote repository.
+
+## pushing submodule changes to the submodule's repo
+
+`cd merkle-tree`
+`git commit -am "commit message"`
+`git push origin master`
+
+Now you can safely push to Nightfall:
+`cd ..`
+`git push  --recurse-submodules=check` (always get in the habit of including the 'check' command)
+
+## checking out a new branch
+
+`git checkout --recurse-submodules master`

--- a/zkp/README.md
+++ b/zkp/README.md
@@ -34,6 +34,12 @@ docker-compose run --rm truffle-zkp compile --all && docker-compose run --rm tru
 
 This will run ganache in a container; compile all of the nightfall contracts; and deploy them.  
 
+Then start the merkle-tree microservice, which will start filtering the Shield contracts and populating the merkle-tree database:
+
+```sh
+docker-compose -f docker-compose.merkle-tree.yml up --build
+```
+
 To run the zkp unit tests (in another terminal window):
 
 ```sh


### PR DESCRIPTION
Reverts EYBlockchain/nightfall#346, which has broken things due to the need to authenticate even when using public packages.