### PR TITLE
trusted setup bug resolved

### DIFF
--- a/nightfall-generate-trusted-setup
+++ b/nightfall-generate-trusted-setup
@@ -40,7 +40,7 @@ generateSetups(){
   selectedSetupsIndexes=$(echo $selectedSetupsIndexes | tr "," "\n")
   for i in $selectedSetupsIndexes
   do
-    npm run setup -- -i gm17/${setups[$i-1]}
+    npm run setup -- -f gm17/${setups[$i-1]}
   done
 }
 

--- a/zkp/code/index.js
+++ b/zkp/code/index.js
@@ -18,16 +18,16 @@ const getDirectories = source =>
     .filter(isDirectory);
 
 /**
- * Trusted setup for Nightfall. Either compiles all directories in /code/gm17, or a single directory using the -i flag.
+ * Trusted setup for Nightfall. Either compiles all directories in /code/gm17, or a single directory using the -f flag.
  * Calls zokrates' compile, setup, and export-verifier on all (or a specified) directories in `/zkp/code/gm17`.
  */
 async function main() {
-  // -i being the name of the .code file (i.e., 'ft-mint')
-  const { i } = argv;
+  // -f being the name of the .code file (i.e., 'ft-mint')
+  const { f } = argv;
 
-  if (!i) {
+  if (!f) {
     console.log(
-      "The '-i' option has not been specified.\nThat's OK, we can go ahead and loop through every .code file.\nHOWEVER, if you wanted to choose just one file, cancel this process, and instead use option -i (see the README-trusted-setup)",
+      "The '-f' option has not been specified.\nThat's OK, we can go ahead and loop through every .code file.\nHOWEVER, if you wanted to choose just one file, cancel this process, and instead use option -f (see the README-trusted-setup)",
     );
     console.log('Be warned, this could take up to an hour!');
 
@@ -55,7 +55,7 @@ async function main() {
       throw new Error(`Trusted setup failed: ${err}`);
     }
   } else {
-    await generateZokratesFiles(`${process.cwd()}/code/${i}`);
+    await generateZokratesFiles(`${process.cwd()}/code/${f}`);
   }
 }
 

--- a/zkp/package.json
+++ b/zkp/package.json
@@ -5,8 +5,8 @@
   "repository": "https://github.com/EYBlockchain/nightfall",
   "main": "index.js",
   "scripts": {
-    "setup": "NODE_ENV=setup npx babel-node code/index.js",
-    "setup-all": "yes | NODE_ENV=setup npx babel-node code/index.js",
+    "setup": "NODE_ENV=setup babel-node code/index.js",
+    "setup-all": "yes | NODE_ENV=setup babel-node code/index.js",
     "start": "nodemon --ignore src/vkIds.json --ignore stats-config/ --ignore code/ --exec babel-node ./src/index.js",
     "test": "jest --verbose --runInBand --forceExit ./__tests__/*.test.js"
   },


### PR DESCRIPTION
# Description
bug resolved as option '-i' was taken by babel-node options instead of code/index.js argument

## Related Issue
fixes #361 

## How Has This Been Tested
By running  `./nightfall-generate-trusted-setup `

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.