### PR TITLE
fix: creates gm17 folder if doesn't exist

### DIFF
--- a/nightfall-generate-trusted-setup
+++ b/nightfall-generate-trusted-setup
@@ -12,6 +12,8 @@ completedSetupList=""
 selectedSetupsIndexes=""
 declare -i index=0
 
+mkdir zkp/code/gm17 || true
+
 # Get available trusted setup names, excluding the 'common' directory
 pushd zkp/code/gm17/
 for d in *


### PR DESCRIPTION
# Description

Fixes ./nightfall-generate-trusted-setup error when gm17 doesn't exist.
Creates folder if code/gm17 cannot be found.

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ x] All new and existing tests passed.