### PR TITLE
Removed 'returns' from RegisterVerificationKey functions

### DIFF
--- a/zkp/contracts/FTokenShield.sol
+++ b/zkp/contracts/FTokenShield.sol
@@ -115,7 +115,8 @@ contract FTokenShield is Ownable, MerkleTree {
       roots[latestRoot] = latestRoot; // and save the new root to the list of roots
 
       // Finally, transfer the fTokens from the sender to this contract
-      fToken.transferFrom(msg.sender, address(this), _value);
+      bool transferCheck = fToken.transferFrom(msg.sender, address(this), _value);
+      require(transferCheck, "Commitment cannot be minted");
 
       // gas measurement:
       gasUsedByShieldContract = gasUsedByShieldContract + gasCheckpoint - gasleft();
@@ -245,7 +246,8 @@ contract FTokenShield is Ownable, MerkleTree {
 
       //Finally, transfer the fungible tokens from this contract to the nominated address
       address payToAddress = address(_payTo); // we passed _payTo as a uint256, to ensure the packing was correct within the sha256() above
-      fToken.transfer(payToAddress, _value);
+      bool transferCheck = fToken.transfer(payToAddress, _value);
+      require(transferCheck, "Commitment cannot be burned");
 
       emit Burn(_nullifier);
 

--- a/zkp/contracts/FTokenShield.sol
+++ b/zkp/contracts/FTokenShield.sol
@@ -78,7 +78,7 @@ contract FTokenShield is Ownable, MerkleTree {
   /**
   Stores verification keys (for the 'mint', 'transfer' and 'burn' computations).
   */
-  function registerVerificationKey(uint256[] calldata _vk, TransactionTypes _txType) external onlyOwner returns (bytes32) {
+  function registerVerificationKey(uint256[] calldata _vk, TransactionTypes _txType) external onlyOwner {
       // CAUTION: we do not prevent overwrites of vk's. Users must listen for the emitted event to detect updates to a vk.
       vks[uint(_txType)] = _vk;
 
@@ -115,8 +115,7 @@ contract FTokenShield is Ownable, MerkleTree {
       roots[latestRoot] = latestRoot; // and save the new root to the list of roots
 
       // Finally, transfer the fTokens from the sender to this contract
-      bool transferCheck = fToken.transferFrom(msg.sender, address(this), _value);
-      require(transferCheck, "Commitment cannot be minted");
+      fToken.transferFrom(msg.sender, address(this), _value);
 
       // gas measurement:
       gasUsedByShieldContract = gasUsedByShieldContract + gasCheckpoint - gasleft();
@@ -246,8 +245,7 @@ contract FTokenShield is Ownable, MerkleTree {
 
       //Finally, transfer the fungible tokens from this contract to the nominated address
       address payToAddress = address(_payTo); // we passed _payTo as a uint256, to ensure the packing was correct within the sha256() above
-      bool transferCheck = fToken.transfer(payToAddress, _value);
-      require(transferCheck, "Commitment cannot be burned");
+      fToken.transfer(payToAddress, _value);
 
       emit Burn(_nullifier);
 

--- a/zkp/contracts/NFTokenShield.sol
+++ b/zkp/contracts/NFTokenShield.sol
@@ -76,7 +76,7 @@ contract NFTokenShield is Ownable, MerkleTree {
     /**
     Stores verification keys (for the 'mint', 'transfer' and 'burn' computations).
     */
-    function registerVerificationKey(uint256[] calldata _vk, TransactionTypes _txType) external onlyOwner returns (bytes32) {
+    function registerVerificationKey(uint256[] calldata _vk, TransactionTypes _txType) external onlyOwner {
         // CAUTION: we do not prevent overwrites of vk's. Users must listen for the emitted event to detect updates to a vk.
         vks[uint(_txType)] = _vk;
 


### PR DESCRIPTION
# Description

The RegisterVerificationKey functions in both shield contract do not return any value, instead they emit an event. This PR removes the expected bytes32 value from them.

## Types of changes

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist


- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.