### PR TITLE
fix: truffle box requires maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,6 @@ These instructions give the most direct path to a working Nightfall setup. The a
 compute-intensive and so a high-end processor is preferred. Depending on your machine, setup can
 take one to several hours.
 
-### Truffle
-
-If you are familiar with [Truffle](https://github.com/trufflesuite/truffle#readme) and would like a
-Truffle-specific way to get started, check out the
-[Nightfall Truffle Box](https://github.com/truffle-box/nightfall-box#nightfall-truffle-box).
-
 ### Supported hardware & prerequisites
 
 Mac and Linux machines with at least 16GB of memory and 10GB of disk space are supported.


### PR DESCRIPTION
# Description

Removed the link to Nightfall Truffle Box.

## Related Issue

Trusted Setup Failing #334

## Motivation and Context

Nightfall Truffle Box requires maintenance and has been outdated since December.

## How Has This Been Tested

Tested on Wednesday Feb 26. Box fails at npm run set up.

System:
macOS 10.14.6, 16GB ram
docker 2.1.1.0.5

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.