### PR TITLE
close container at the end of nightfall bash scripts

### DIFF
--- a/nightfall
+++ b/nightfall
@@ -30,32 +30,36 @@ launchContainers(){
   docker-compose up
 }
 
-printf "${GREEN}*** Cleaning up all containers ***${NC}\n"
-docker-compose down -v || {
-	# this block will run if ```docker-compose down -v``` fails.
-	sleep 3
+cleanup(){
+  printf "${GREEN}*** Cleaning up all containers ***${NC}\n"
+  docker-compose down -v || {
+    # this block will run if ```docker-compose down -v``` fails.
+    sleep 3
 
-	printf "${GREEN}*** Remove nightfall network ***${NC}\n"
-  docker network rm nightfall_network
+    printf "${GREEN}*** Remove nightfall network ***${NC}\n"
+    docker network rm nightfall_network
 
-  printf "${GREEN}*** Remove nightfall's mongo volume ***${NC}\n"
-  docker volume rm nightfall_mongo-nightfall-volume
+    printf "${GREEN}*** Remove nightfall's mongo volume ***${NC}\n"
+    docker volume rm nightfall_mongo-nightfall-volume
 
-  printf "${GREEN}*** Remove zkp-code volume ***${NC}\n"
-  docker volume rm nightfall_zkp-code-volume
+    printf "${GREEN}*** Remove zkp-code volume ***${NC}\n"
+    docker volume rm nightfall_zkp-code-volume
 
-	printf "${GREEN}*** Remove merkle_tree network ***${NC}\n"
-  docker network rm merkle_tree_network
+    printf "${GREEN}*** Remove merkle_tree network ***${NC}\n"
+    docker network rm merkle_tree_network
 
-	printf "${GREEN}*** Remove the merkle tree's mongo volume ***${NC}\n"
-  docker volume rm nightfall_mongo-merkle-tree-volume
+    printf "${GREEN}*** Remove the merkle tree's mongo volume ***${NC}\n"
+    docker volume rm nightfall_mongo-merkle-tree-volume
+  }
+
+  printf  "${GREEN}*** Delete files created by previous run ***${NC}\n"
+  rm -dr zkp/build/ || true
+  rm -dr offchain/build/ || true
+  rm zkp/contracts/MerkleTree.sol || true
+  rm docker-compose.override.yml || true
 }
 
-printf  "${GREEN}*** Delete files created by previous run ***${NC}\n"
-rm -dr zkp/build/ || true
-rm -dr offchain/build/ || true
-rm zkp/contracts/MerkleTree.sol || true
-rm docker-compose.override.yml || true
+cleanup
 
 printf "${GREEN}*** Pull zokrates docker image ***${NC}\n"
 docker pull zokrates/zokrates:0.5.1
@@ -73,3 +77,5 @@ then
 else
   launchContainers
 fi
+
+cleanup

--- a/nightfall-test
+++ b/nightfall-test
@@ -46,15 +46,34 @@ launchContainersAndRunIntegrationTest(){
   npm run $1 || isTestFailed=true
 }
 
+cleanup(){
+  printf "${GREEN}*** Cleaning up all containers ***${NC}\n"
+  docker-compose down -v || {
+    # delay need as waiting time so all container are properly done
+    # nightfall_default network have no dependency left.
+    sleep 3
 
-printf "${GREEN}*** Cleaning up all test containers ***${NC}\n"
-docker-compose down -v || true
+    printf "${GREEN}*** Remove nightfall network ***${NC}\n"
+    docker network rm nightfall_network
 
-printf  "${GREEN}*** Delete files created by previous run ***${NC}\n"
-rm -dr zkp/build/ || true
-rm -dr offchain/build/ || true
-rm zkp/contracts/MerkleTree.sol || true
-rm docker-compose.override.yml || true
+    printf "${GREEN}*** Remove nightfall's mongo volume ***${NC}\n"
+    docker volume rm nightfall_mongo-nightfall-volume
+
+    printf "${GREEN}*** Remove zkp-code volume ***${NC}\n"
+    docker volume rm nightfall_zkp-code-volume
+
+    printf "${GREEN}*** Remove the merkle tree's mongo volume ***${NC}\n"
+    docker volume rm nightfall_mongo-merkle-tree-volume
+  }
+
+  printf  "${GREEN}*** Delete files created by previous run ***${NC}\n"
+  rm -dr zkp/build/ || true
+  rm -dr offchain/build/ || true
+  rm zkp/contracts/MerkleTree.sol || true
+  rm docker-compose.override.yml || true
+}
+
+cleanup
 
 printf "${GREEN}*** Pull zokrates docker image ***${NC}\n"
 docker pull zokrates/zokrates:0.5.1
@@ -81,24 +100,7 @@ df -h
 printf "${GREEN}*** List all containers with their Ips ***${NC}\n"
 docker inspect -f '{{.Name}} {{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $(docker-compose ps -q)
 
-printf "${GREEN}*** Cleaning up all containers ***${NC}\n"
-docker-compose down -v || {
-  # delay need as waiting time so all container are properly done
-  # nightfall_default network have no dependency left.
-  sleep 3
-
-  printf "${GREEN}*** Remove nightfall network ***${NC}\n"
-  docker network rm nightfall_network
-
-  printf "${GREEN}*** Remove nightfall's mongo volume ***${NC}\n"
-  docker volume rm nightfall_mongo-nightfall-volume
-
-  printf "${GREEN}*** Remove zkp-code volume ***${NC}\n"
-  docker volume rm nightfall_zkp-code-volume
-
-  printf "${GREEN}*** Remove the merkle tree's mongo volume ***${NC}\n"
-  docker volume rm nightfall_mongo-merkle-tree-volume
-}
+cleanup
 
 if $isTestFailed
 then


### PR DESCRIPTION
# Description
update `./nightfall` and `./nightfall-test` bash script to close containers and deleted generated files before exiting.

## Related Issue
fixes #442 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.