### PR TITLE
fixes nightfall-generate-trusted-setup script

### DIFF
--- a/nightfall-generate-trusted-setup
+++ b/nightfall-generate-trusted-setup
@@ -24,6 +24,7 @@ case $yn in
     setupAllCmd=setupAll-mimc
     mimc=yes
     mkdir zkp/code/gm17/ft-batch-transfer zkp/code/gm17/ft-burn zkp/code/gm17/ft-consolidation-transfer zkp/code/gm17/ft-mint zkp/code/gm17/ft-transfer zkp/code/gm17/nft-burn zkp/code/gm17/nft-mint zkp/code/gm17/nft-transfer || true
+    cp docker-compose.override.mimc.yml docker-compose.override.yml
     ;;
   [Nn]* )
     ;;
@@ -38,6 +39,7 @@ if [ ${setupCmd} != "setup-mimc" ]
         setupCmd=setup-rc
         setupAllCmd=setupAll-rc
         mkdir zkp/code/gm17/ft-burn zkp/code/gm17/ft-mint zkp/code/gm17/ft-transfer || true
+        cp docker-compose.override.compliance.yml docker-compose.override.yml
         ;;
       [Nn]* ) mkdir zkp/code/gm17/ft-batch-transfer zkp/code/gm17/ft-burn zkp/code/gm17/ft-mint zkp/code/gm17/ft-transfer zkp/code/gm17/nft-burn zkp/code/gm17/nft-mint zkp/code/gm17/nft-transfer || true
         ;;


### PR DESCRIPTION

# Description
Fixes bug for MiMC hash, cases where after generating setup (by running `nightfall-generate-trusted-setup` script) user try to zkp unit tests

## How Has This Been Tested
By running zkp uint test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.